### PR TITLE
add magic ThisType<T> definition

### DIFF
--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -866,3 +866,8 @@ type ReturnType<T extends (...args: Array<any>) => any> = T extends (...args: Ar
 type InstanceType<T extends new (...args: Array<any>) => any> = T extends new (...args: Array<any>) => infer R
 	? R
 	: any;
+
+/**
+ * Marker for contextual 'this' type
+ */
+interface ThisType<T> { }


### PR DESCRIPTION
Typescript has a built-in magic `ThisType<T>` that can be used as a contextual `this`
****Example:****
```ts
type ObjectDescriptor<D, M> = {
    data?: D;
    methods?: M & ThisType<D & M>;  // Type of 'this' in methods is D & M
}

function makeObject<D, M>(desc: ObjectDescriptor<D, M>): D & M {
    let data: object = desc.data || {};
    let methods: object = desc.methods || {};
    return { ...data, ...methods } as D & M;
}

let obj = makeObject({
    data: { x: 0, y: 0 },
    methods: {
        moveBy(dx: number, dy: number) {
            this.x += dx;  // Strongly typed this
            this.y += dy;  // Strongly typed this
        }
    }
});

obj.x = 10;
obj.y = 20;
obj.moveBy(5, 5);
```