### PR TITLE
Exclude false and undefined from assert

### DIFF
--- a/include/lua.d.ts
+++ b/include/lua.d.ts
@@ -13,7 +13,7 @@ declare const _G: Table;
 declare const _VERSION: string;
 
 /** Throws an error if the provided value is false or nil . Returns the value that was passed into the function if the assertion passes. */
-declare function assert<T>(condition: T, message?: string): T;
+declare function assert<T>(condition: T, message?: string): Exclude<T, false | undefined>;
 
 /** Performs an operation on the Lua garbage collector based on the specified option. Roblox's Lua sandbox only allows the "count" option to be used, so none of the other standard options are available. The "count" option returns the total memory in use by Lua (in kilobytes). */
 declare function collectgarbage(option: "count"): number;


### PR DESCRIPTION
For example, means that the following code:

`assert(ReplicatedStorage.FindFirstChild("Foo"))!.Name`

...can be turned into

`assert(ReplicatedStorage.FindFirstChild("Foo")).Name`

...just like in Lua.

Also helpfully makes `assert(false)` and `assert(undefined)` evaluate to `never`, though this doesn't seem to stop any compiling.