### PR TITLE
Change Object.assign signature

### DIFF
--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -37,7 +37,7 @@ interface ObjectConstructor {
 		source4: E,
 		source5: F,
 	): A & B & C & D & E & F;
-	assign(target: object, ...sources: Array<any>): any;
+	assign(target: object, ...sources: Array<any>): object;
 
 	/**
 	 * Returns the names of the enumerable properties and methods of an object.


### PR DESCRIPTION
I think Object.assign is better typed as having an `object` return type. We could optionally change `...sources: Array<any>` to `...sources: Array<object>` and force `A`, `B`, `C`, `D`, `E`, and `F` to extend from `object`. I just ran into a compiler error where I had a function like `() => Object.assign({}, ...arr.map(a => a()))`, where `arr.map(a => a())` evaluates to `Array<object>`.