### PR TITLE
any => void

### DIFF
--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -186,7 +186,7 @@ interface SymbolConstructor {
 }
 declare var Symbol: SymbolConstructor;
 
-type IteratorResult<Yields, Returns = any> = IteratorYieldResult<Yields> | IteratorReturnResult<Returns>;
+type IteratorResult<Yields, Returns = void> = IteratorYieldResult<Yields> | IteratorReturnResult<Returns>;
 
 interface IteratorYieldResult<Yields> {
 	done: false;
@@ -198,12 +198,12 @@ interface IteratorReturnResult<Returns> {
 	value: Returns;
 }
 
-interface Iterator<Yields, Returns = any, Next = undefined> {
+interface Iterator<Yields, Returns = void, Next = undefined> {
 	// Takes either 0 or 1 arguments - doesn't accept 'undefined'
 	next(...args: [] | [Next]): IteratorResult<Yields, Returns>;
 }
 
-interface Generator<Yields = unknown, Returns = any, Next = unknown> extends Iterator<Yields, Returns, Next> {
+interface Generator<Yields = unknown, Returns = void, Next = unknown> extends Iterator<Yields, Returns, Next> {
 	next(...args: [] | [Next]): IteratorResult<Yields, Returns>;
 	[Symbol.iterator](): Generator<Yields, Returns, Next>;
 }


### PR DESCRIPTION
This should help with generator types which can sometimes get defined as `any | T`, which evaluates to `any`, losing the types. It makes sense to me to default to void, since functions default to returning void, and we currently don't even support returning from generators.