### PR TITLE
Narrow FindPartsInRegion3* return types

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -835,19 +835,19 @@ interface Workspace extends Model {
 	FindPartsInRegion3(
 		region: Region3,
 		ignoreDescendantsInstance?: Instance,
-		maxParts?: number
+		maxParts?: number,
 	): Array<BasePart>;
 
 	FindPartsInRegion3WithIgnoreList(
 		region: Region3,
 		ignoreDescendantsTable: Array<Instance>,
-		maxParts?: number
+		maxParts?: number,
 	): Array<BasePart>;
 
 	FindPartsInRegion3WithWhiteList(
 		region: Region3,
 		whitelistDescendantsTable: Array<Instance>,
-		maxParts?: number
+		maxParts?: number,
 	): Array<BasePart>;
 }
 

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -831,6 +831,24 @@ interface Workspace extends Model {
 		whitelistDescendantsTable: Array<Instance>,
 		ignoreWater?: boolean,
 	): LuaTuple<[BasePart | undefined, Vector3, Vector3, Enum.Material]>;
+
+	FindPartsInRegion3(
+		region: Region3,
+		ignoreDescendantsInstance?: Instance,
+		maxParts?: number
+	): Array<BasePart>;
+
+	FindPartsInRegion3WithIgnoreList(
+		region: Region3,
+		ignoreDescendantsTable: Array<Instance>,
+		maxParts?: number
+	): Array<BasePart>;
+
+	FindPartsInRegion3WithWhiteList(
+		region: Region3,
+		whitelistDescendantsTable: Array<Instance>,
+		maxParts?: number
+	): Array<BasePart>;
 }
 
 /**


### PR DESCRIPTION
According to the docs for `FindPartsInRegion3`, the method and its derivatives should return "An array of `BasePart`s within the `DataType/Region3`. However, the generated types return an `Array<Instance>`. This PR narrows the return types to `Array<BasePart>`.