### PR TITLE
Change NonNullable so that it changes unknown/any to {}

### DIFF
--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -987,7 +987,7 @@ type Extract<T, U> = T extends U ? T : never;
 /**
  * Exclude null and undefined from T
  */
-type NonNullable<T> = T extends null | undefined ? never : T;
+type NonNullable<T> = unknown extends T ? {} : T extends null | undefined ? never : T;
 
 /**
  * Obtain the parameters of a function type in a `tuple | never`.


### PR DESCRIPTION
With the new changes, NonNullable should satisfy the following conditions:
NonNullable<unknown> -> {}
NonNullable<any> -> {}

Keep in mind any value is assignable to `{}` except `null | undefined`