### PR TITLE
Exclude non-enumerable Roblox datatypes from being unioned

### DIFF
--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -73,7 +73,7 @@ interface ObjectConstructor {
 					{
 						[K in Exclude<keyof S, keyof Array<unknown> | "length">]: Exclude<
 							S[K],
-							CheckableTypes[Exclude<keyof CheckableTypes, keyof CheckablePrimitives>] // Exclude non-enumerable Roblox datatypes from being unioned
+							CheckableTypes[Exclude<keyof CheckableTypes, keyof CheckablePrimitives> | "function" | "thread"] // Exclude non-enumerable Roblox datatype objects from being unioned
 						> extends infer M
 							? ((M extends object
 								? M

--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -61,7 +61,7 @@ interface ObjectConstructor {
 	assign<A extends object, S extends Array<unknown>>(
 		this: ObjectConstructor,
 		target: A,
-		...sources: A extends CheckableTypes[Exclude<keyof CheckableTypes, keyof CheckablePrimitives | "Instance"> | "function" | "thread"] // invalidate calls when target is a Vector2/Vector3/function/etc
+		...sources: A extends CheckableTypes[Exclude<keyof CheckableTypes, keyof CheckablePrimitives | "Instance"> | "function"] // invalidate calls when target is a Vector2/Vector3/function/etc
 			? never
 			: A extends Instance
 			? Array<PartialInstance<A> | undefined | boolean | string | number | Callback | thread>

--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -61,7 +61,7 @@ interface ObjectConstructor {
 	assign<A extends object, S extends Array<unknown>>(
 		this: ObjectConstructor,
 		target: A,
-		...sources: A extends CheckableTypes[Exclude<keyof CheckableTypes, keyof CheckablePrimitives | "Instance">] // invalidate calls when target is a Vector2/Vector3/etc
+		...sources: A extends CheckableTypes[Exclude<keyof CheckableTypes, keyof CheckablePrimitives | "Instance"> | "function" | "thread"] // invalidate calls when target is a Vector2/Vector3/function/etc
 			? never
 			: A extends Instance
 			? Array<PartialInstance<A> | undefined | boolean | string | number | Callback | thread>

--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -71,7 +71,10 @@ interface ObjectConstructor {
 		: A &
 				UnionToIntersection<
 					{
-						[K in Exclude<keyof S, keyof Array<unknown> | "length">]: S[K] extends infer M
+						[K in Exclude<keyof S, keyof Array<unknown> | "length">]: Exclude<
+							S[K],
+							CheckableTypes[Exclude<keyof CheckableTypes, keyof CheckablePrimitives>] // Exclude non-enumerable Roblox datatypes from being unioned
+						> extends infer M
 							? ((M extends object
 								? M
 								: undefined) extends undefined


### PR DESCRIPTION
Now, Instances/Vector2s/Vector3s/functions/threads that occur as the second or following arguments will not write to the final type.
```ts
const t = Object.assign({ x: 1 }, new Instance("Part"), new Vector3()); // { x: number; }
```

Also, it is now invalid to assign to a function:
```ts
Object.assign(() => 1, { x: 1 }); // error
```