### PR TITLE
Remove fallbacks

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -318,32 +318,26 @@ interface Instance {
 	WaitForChild(this: Instance, childName: string, timeOut: number): Instance | undefined;
 
 	IsA<T extends keyof Instances>(this: Instance, className: T): this is Instances[T];
-	IsA(this: Instance, className: string): boolean;
 
 	FindFirstAncestorWhichIsA<T extends keyof Instances>(this: Instance, className: T): Instances[T] | undefined;
-	FindFirstAncestorWhichIsA(this: Instance, className: string): Instance | undefined;
 
 	FindFirstChildWhichIsA<T extends keyof Instances>(
 		this: Instance,
 		className: T,
 		recursive?: boolean,
 	): Instances[T] | undefined;
-	FindFirstChildWhichIsA(this: Instance, className: string, recursive?: boolean): Instance | undefined;
 
 	FindFirstAncestorOfClass<T extends keyof StrictInstances>(
 		this: Instance,
 		className: T,
 	): StrictInstances[T] | undefined;
-	FindFirstAncestorOfClass(this: Instance, className: string): Instance | undefined;
 
 	FindFirstChildOfClass<T extends keyof StrictInstances>(
 		this: Instance,
 		className: T,
 	): StrictInstances[T] | undefined;
-	FindFirstChildOfClass(this: Instance, className: string): Instance | undefined;
 
 	GetPropertyChangedSignal(this: Instance, propertyName: InstanceProperties<this>): RBXScriptSignal;
-	GetPropertyChangedSignal(this: Instance, propertyName: string): RBXScriptSignal;
 }
 
 interface InventoryPages extends Pages<number> {}
@@ -610,7 +604,6 @@ interface ServiceProvider<S = unknown> extends Instance {
 	FindService(this: ServiceProvider<S>, className: string): S[keyof S] | undefined;
 	FindService(this: ServiceProvider<S>, className: string): Instance | undefined;
 	GetService<T extends keyof S>(this: ServiceProvider<S>, className: T): S[T];
-	GetService(this: ServiceProvider<S>, className: string): S[keyof S] | undefined;
 }
 
 interface SocialService extends Instance {

--- a/include/generated/None.d.ts
+++ b/include/generated/None.d.ts
@@ -483,7 +483,6 @@ interface Instance {
 		this: Instance,
 		className: T,
 	): StrictInstances[T] | undefined;
-	FindFirstAncestorOfClass(this: Instance, className: string): Instance | undefined;
 	/** Returns the first ancestor of the `Instance` for whom [Instance.IsA](https://developer.roblox.com/api-reference/function/Instance/IsA) returns true for the given className.
 	 * 
 	 * This function works upwards, meaning it starts at the `Instance`'s immediate [Instance.Parent](https://developer.roblox.com/api-reference/property/Instance/Parent) and works up towards the `DataModel`. If no matching ancestor is found, it returns nil.
@@ -507,7 +506,6 @@ interface Instance {
 	 * @returns The `Instance` found.
 	 */
 	FindFirstAncestorWhichIsA<T extends keyof Instances>(this: Instance, className: T): Instances[T] | undefined;
-	FindFirstAncestorWhichIsA(this: Instance, className: string): Instance | undefined;
 	/** Returns the first child of the `Instance` found with the given name. If no child exists with the given name, this function returns nil. If the optional recursive argument is true, this function searches all descendants rather than only the immediate children of the `Instance`. Use this function if your code cannot guarantee the existence of an object with a given name.
 	 * 
 	 * ## Checking the Existence of An Object
@@ -575,7 +573,6 @@ interface Instance {
 		this: Instance,
 		className: T,
 	): StrictInstances[T] | undefined;
-	FindFirstChildOfClass(this: Instance, className: string): Instance | undefined;
 	/** Returns the first child of the `Instance` for whom [Instance.IsA](https://developer.roblox.com/api-reference/function/Instance/IsA) returns true for the given className.
 	 * 
 	 * If no matching child is found, this function returns nil. If the optional recursive argument is true, this function searches all descendants rather than only the immediate children of the `Instance`.
@@ -604,7 +601,6 @@ interface Instance {
 		className: T,
 		recursive?: boolean,
 	): Instances[T] | undefined;
-	FindFirstChildWhichIsA(this: Instance, className: string, recursive?: boolean): Instance | undefined;
 	GetAttribute(this: Instance, attribute: string): unknown;
 	GetAttributeChangedSignal(this: Instance, attribute: string): RBXScriptSignal;
 	GetAttributes(this: Instance): object;
@@ -678,7 +674,6 @@ interface Instance {
 	 * `ValueBase` objects, such as `IntValue` and `StringValue`, use a modified `Changed` event that fires with the contents of the `Value` property. As such, this method provides a way to detect changes in other properties of those objects. For example, to detect changes in the `Name` property of an `IntValue`, use `IntValue:GetPropertyChangedSignal("Name"):Connect(someFunc)` since the `Changed` event of `IntValue` objects only detect changes on the `Value` property.
 	 */
 	GetPropertyChangedSignal(this: Instance, propertyName: InstanceProperties<this>): RBXScriptSignal;
-	GetPropertyChangedSignal(this: Instance, propertyName: string): RBXScriptSignal;
 	/** IsA returns true if the `Instance`'s class is **equivalent to** or a **subclass** of a given class. This function is similar to the **instanceof** operators in other languages, and is a form of [type introspection](https://en.wikipedia.org/wiki/Type_introspection). To ignore class inheritance, test the [ClassName](https://developer.roblox.com/api-reference/property/Instance/ClassName) property directly instead. For checking native Lua data types (number, string, etc) use the functions `type` and `typeof`.
 	 * 
 	 * Most commonly, this function is used to test if an object is some kind of part, such as `Part` or `WedgePart`, which inherits from `BasePart` (an abstract class). For example, if your goal is to change all of a [Character](https://developer.roblox.com/api-reference/property/Player/Character)'s limbs to the same color, you might use [GetChildren](https://developer.roblox.com/api-reference/function/Instance/GetChildren) to iterate over the children, then use IsA to filter non-`BasePart` objects which lack the `BrickColor` property:
@@ -702,7 +697,6 @@ interface Instance {
 	 * @returns Describes whether the Instance's class matched or is a subclass of the given class
 	 */
 	IsA<T extends keyof Instances>(this: Instance, className: T): this is Instances[T];
-	IsA(this: Instance, className: string): boolean;
 	/** Returns true if an `Instance` is an ancestor of the given descendant.
 	 * 
 	 * An `Instance` is considered the ancestor of an object if the object's [Instance.Parent](https://developer.roblox.com/api-reference/property/Instance/Parent) or one of it's parent's [Instance.Parent](https://developer.roblox.com/api-reference/property/Instance/Parent) is set to the `Instance`.
@@ -15458,7 +15452,6 @@ interface ServiceProvider<S = unknown> extends Instance {
 	 * * If you attempt to fetch a service that is present under another Object, an error will be thrown stating that the "singleton serviceName already exists".
 	 */
 	GetService<T extends keyof S>(this: ServiceProvider<S>, className: T): S[T];
-	GetService(this: ServiceProvider<S>, className: string): S[keyof S] | undefined;
 	/** Fires when the current place is exited. */
 	readonly Close: RBXScriptSignal<() => void>;
 	/** Fired when a service is created. */

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -614,17 +614,6 @@ interface InstanceConstructor {
 	 * You can read [this thread on the developer forum](https://devforum.roblox.com/t/psa-dont-use-instance-new-with-parent-argument/30296) for more information.
 	 */
 	new <T extends keyof CreatableInstances>(className: T, parent?: Instance): StrictInstances[T];
-	/**
-	 * Creates an new object of type val. The parent argument is optional;
-	 * If it is supplied, the object will be parented to that object.
-	 * Performance note: When the Parent of an object is set,
-	 * Roblox begins listening to a variety of different property changes for replication,
-	 * rendering and physics.
-	 * Therefore, it is recommended to set the Parent property last when creating new objects.
-	 * As such, you should avoid using the second argument (parent) of this function.
-	 * You can read [this thread on the developer forum](https://devforum.roblox.com/t/psa-dont-use-instance-new-with-parent-argument/30296) for more information.
-	 */
-	new (className: string, parent?: Instance): Instance;
 }
 
 declare const Instance: InstanceConstructor;
@@ -893,134 +882,134 @@ interface BrickColorsByNumber {
 }
 
 interface BrickColorsByPalette {
-	[0]: 141;
-	[1]: 301;
-	[2]: 107;
-	[3]: 26;
-	[4]: 1012;
-	[5]: 303;
-	[6]: 1011;
-	[7]: 304;
-	[8]: 28;
-	[9]: 1018;
-	[10]: 302;
-	[11]: 305;
-	[12]: 306;
-	[13]: 307;
-	[14]: 308;
-	[15]: 1021;
-	[16]: 309;
-	[17]: 310;
-	[18]: 1019;
-	[19]: 135;
-	[20]: 102;
-	[21]: 23;
-	[22]: 1010;
-	[23]: 312;
-	[24]: 313;
-	[25]: 37;
-	[26]: 1022;
-	[27]: 1020;
-	[28]: 1027;
-	[29]: 311;
-	[30]: 315;
-	[31]: 1023;
-	[32]: 1031;
-	[33]: 316;
-	[34]: 151;
-	[35]: 317;
-	[36]: 318;
-	[37]: 319;
-	[38]: 1024;
-	[39]: 314;
-	[40]: 1013;
-	[41]: 1006;
-	[42]: 321;
-	[43]: 322;
-	[44]: 104;
-	[45]: 1008;
-	[46]: 119;
-	[47]: 323;
-	[48]: 324;
-	[49]: 325;
-	[50]: 320;
-	[51]: 11;
-	[52]: 1026;
-	[53]: 1016;
-	[54]: 1032;
-	[55]: 1015;
-	[56]: 327;
-	[57]: 1005;
-	[58]: 1009;
-	[59]: 29;
-	[60]: 328;
-	[61]: 1028;
-	[62]: 208;
-	[63]: 45;
-	[64]: 329;
-	[65]: 330;
-	[66]: 331;
-	[67]: 1004;
-	[68]: 21;
-	[69]: 332;
-	[70]: 333;
-	[71]: 24;
-	[72]: 334;
-	[73]: 226;
-	[74]: 1029;
-	[75]: 335;
-	[76]: 336;
-	[77]: 342;
-	[78]: 343;
-	[79]: 338;
-	[80]: 1007;
-	[81]: 339;
-	[82]: 133;
-	[83]: 106;
-	[84]: 340;
-	[85]: 341;
-	[86]: 1001;
-	[87]: 1;
-	[88]: 9;
-	[89]: 1025;
-	[90]: 337;
-	[91]: 344;
-	[92]: 345;
-	[93]: 1014;
-	[94]: 105;
-	[95]: 346;
-	[96]: 347;
-	[97]: 348;
-	[98]: 349;
-	[99]: 1030;
-	[100]: 125;
-	[101]: 101;
-	[102]: 350;
-	[103]: 192;
-	[104]: 351;
-	[105]: 352;
-	[106]: 353;
-	[107]: 354;
-	[108]: 1002;
-	[109]: 5;
-	[110]: 18;
-	[111]: 217;
-	[112]: 355;
-	[113]: 356;
-	[114]: 153;
-	[115]: 357;
-	[116]: 358;
-	[117]: 359;
-	[118]: 360;
-	[119]: 38;
-	[120]: 361;
-	[121]: 362;
-	[122]: 199;
-	[123]: 194;
-	[124]: 363;
-	[125]: 364;
-	[126]: 365;
-	[127]: 1003;
+	0: 141;
+	1: 301;
+	2: 107;
+	3: 26;
+	4: 1012;
+	5: 303;
+	6: 1011;
+	7: 304;
+	8: 28;
+	9: 1018;
+	10: 302;
+	11: 305;
+	12: 306;
+	13: 307;
+	14: 308;
+	15: 1021;
+	16: 309;
+	17: 310;
+	18: 1019;
+	19: 135;
+	20: 102;
+	21: 23;
+	22: 1010;
+	23: 312;
+	24: 313;
+	25: 37;
+	26: 1022;
+	27: 1020;
+	28: 1027;
+	29: 311;
+	30: 315;
+	31: 1023;
+	32: 1031;
+	33: 316;
+	34: 151;
+	35: 317;
+	36: 318;
+	37: 319;
+	38: 1024;
+	39: 314;
+	40: 1013;
+	41: 1006;
+	42: 321;
+	43: 322;
+	44: 104;
+	45: 1008;
+	46: 119;
+	47: 323;
+	48: 324;
+	49: 325;
+	50: 320;
+	51: 11;
+	52: 1026;
+	53: 1016;
+	54: 1032;
+	55: 1015;
+	56: 327;
+	57: 1005;
+	58: 1009;
+	59: 29;
+	60: 328;
+	61: 1028;
+	62: 208;
+	63: 45;
+	64: 329;
+	65: 330;
+	66: 331;
+	67: 1004;
+	68: 21;
+	69: 332;
+	70: 333;
+	71: 24;
+	72: 334;
+	73: 226;
+	74: 1029;
+	75: 335;
+	76: 336;
+	77: 342;
+	78: 343;
+	79: 338;
+	80: 1007;
+	81: 339;
+	82: 133;
+	83: 106;
+	84: 340;
+	85: 341;
+	86: 1001;
+	87: 1;
+	88: 9;
+	89: 1025;
+	90: 337;
+	91: 344;
+	92: 345;
+	93: 1014;
+	94: 105;
+	95: 346;
+	96: 347;
+	97: 348;
+	98: 349;
+	99: 1030;
+	100: 125;
+	101: 101;
+	102: 350;
+	103: 192;
+	104: 351;
+	105: 352;
+	106: 353;
+	107: 354;
+	108: 1002;
+	109: 5;
+	110: 18;
+	111: 217;
+	112: 355;
+	113: 356;
+	114: 153;
+	115: 357;
+	116: 358;
+	117: 359;
+	118: 360;
+	119: 38;
+	120: 361;
+	121: 362;
+	122: 199;
+	123: 194;
+	124: 363;
+	125: 364;
+	126: 365;
+	127: 1003;
 }
 
 interface BrickColorConstructor {
@@ -1049,9 +1038,6 @@ interface BrickColorConstructor {
 		{ [K in keyof BrickColorsByNumber]: T extends BrickColorsByNumber[K] ? K : never }[keyof BrickColorsByNumber],
 		T
 	>;
-
-	/** Constructs a BrickColor from its name. */
-	new (val: string): BrickColor;
 
 	/** Constructs a BrickColor from its numerical index. */
 	new <T extends keyof BrickColorsByNumber>(val: T): BrickColor<T, BrickColorsByNumber[T]>;
@@ -1647,7 +1633,6 @@ if (typeIs(v, "Vector3")) {
 ```
  **/
 declare function typeIs<T extends keyof CheckableTypes>(value: any, type: T): value is CheckableTypes[T];
-declare function typeIs(value: any, type: string): boolean;
 
 /**
  * Calls the function func with the given arguments in protected mode.


### PR DESCRIPTION
This will help improve type safety for all related functions.

Note: I didn't remove the `BrickColor.new(num: number)` fallback (the better overload has `keyof BrickColorsByNumber` instead of `number`). Keep in mind that `BrickColor.new` won't error if you pass in a bad number, it will just return the "Medium stone grey" `BrickColor`. This is kind of an edge case anyway.