### PR TITLE
Allow Bindable/Remote Event/Function to have type arguments

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -575,15 +575,16 @@ interface PolicyService extends Instance {
 
 interface RemoteEvent<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
 	readonly OnClientEvent: RBXScriptSignal<T>;
-	/** The reason we DON'T allow you to use `Parameters<T>` here is because you can't trust data from the client. Please type-check and sanity-check all values received from the client. E.g. if you are expecting a number from the client, you should check whether a given value is a number and you might also want to make sure it isn't a `NaN` value. In code, this looks like:
-	 * @example
+	/** The reason we DON'T allow you to use `Parameters<T>` here is because you can't trust data from the client. Please type-check and sanity-check all values received from the client. E.g. if you are expecting a number from the client, you should check whether the received value is indeed a number and you might also want to make sure it isn't a `NaN` value. See example code:
+	 * ```ts
 	 * (new Instance("RemoteEvent") as RemoteEvent<(num: number) => void>).OnServerEvent.Connect((plr, num) => {
-	 * 	if (typeIs(num, "number") && num === num) {
-	 * 		print(`Yay! Valid number: ${num}`);
-	 * 	} else {
-	 * 		print(`Bad argument received from ${plr.Name}! Exploit or bug?`);
-	 * 	}
+	 *     if (typeIs(num, "number") && num === num) {
+	 *         print(`Yay! Valid number: ${num}`);
+	 *     } else {
+	 *         print(`Bad argument received from ${plr.Name}! Exploit or bug?`);
+	 *     }
 	 * });
+	 * ```
 	 */
 	readonly OnServerEvent: RBXScriptSignal<(player: Player, ...args: Array<unknown>) => void>;
 	FireAllClients(this: RemoteEvent, ...args: Parameters<T>): void;
@@ -593,15 +594,16 @@ interface RemoteEvent<T extends (...args: Array<any>) => void = (...args: Array<
 
 interface RemoteFunction<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
 	OnClientInvoke: T;
-	/** The reason we DON'T allow you to use `Parameters<T>` here is because you can't trust data from the client. Please type-check and sanity-check all values received from the client. E.g. if you are expecting a number from the client, you should check whether a given value is a number and you might also want to make sure it isn't a `NaN` value. In code, this looks like:
-	 * @example
+	/** The reason we DON'T allow you to use `Parameters<T>` here is because you can't trust data from the client. Please type-check and sanity-check all values received from the client. E.g. if you are expecting a number from the client, you should check whether the received value is indeed a number and you might also want to make sure it isn't a `NaN` value. See example code:
+	 * ```ts
 	 * (new Instance("RemoteFunction") as RemoteFunction<(num: number) => void>).OnServerInvoke = (plr, num) => {
-	 * 	if (typeIs(num, "number") && num === num) {
-	 * 		print(`Yay! Valid number: ${num}`);
-	 * 	} else {
-	 * 		print(`Bad argument received from ${plr.Name}! Exploit or bug?`);
-	 * 	}
+	 *     if (typeIs(num, "number") && num === num) {
+	 *         print(`Yay! Valid number: ${num}`);
+	 *     } else {
+	 *         print(`Bad argument received from ${plr.Name}! Exploit or bug?`);
+	 *     }
 	 * };
+	 * ```
 	 */
 	OnServerInvoke: (player: Player, ...args: Array<unknown>) => void;
 	InvokeClient(this: RemoteFunction, player: Player, ...args: Parameters<T>): unknown;

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -3,7 +3,7 @@ interface AnimationController extends Instance {
 	LoadAnimation(this: AnimationController, animation: Animation): AnimationTrack;
 }
 
-interface AnimationTrack {
+interface AnimationTrack extends Instance {
 	GetMarkerReachedSignal(this: AnimationTrack, name: string): RBXScriptSignal<(param?: string) => void>;
 }
 
@@ -77,14 +77,14 @@ interface BillboardGui extends LayerCollector {
 	PlayerToHideFrom: Player | undefined;
 }
 
-interface BindableEvent extends Instance {
-	readonly Event: RBXScriptSignal<(...arguments: Array<any>) => void>;
-	Fire(this: BindableEvent, ...arguments: Array<unknown>): void;
+interface BindableEvent<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
+	readonly Event: RBXScriptSignal<T>;
+	Fire(this: BindableEvent, ...args: Parameters<T>): void;
 }
 
-interface BindableFunction extends Instance {
-	OnInvoke: (...arguments: Array<unknown>) => any;
-	Invoke(this: BindableFunction, ...arguments: Array<unknown>): Array<unknown>;
+interface BindableFunction<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
+	OnInvoke: T;
+	Invoke(this: BindableFunction, ...args: Parameters<T>): ReturnType<T>;
 }
 
 interface Camera extends Instance {
@@ -573,19 +573,39 @@ interface PolicyService extends Instance {
 	GetPolicyInfoForPlayerAsync(this: PolicyService, player: Player): PolicyInfo;
 }
 
-interface RemoteEvent extends Instance {
-	readonly OnClientEvent: RBXScriptSignal<(...arguments: Array<any>) => void>;
-	readonly OnServerEvent: RBXScriptSignal<(player: Player, ...arguments: Array<unknown>) => void>;
-	FireAllClients(this: RemoteEvent, ...arguments: Array<unknown>): void;
-	FireClient(this: RemoteEvent, player: Player, ...arguments: Array<unknown>): void;
-	FireServer(this: RemoteEvent, ...arguments: Array<unknown>): void;
+interface RemoteEvent<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
+	readonly OnClientEvent: RBXScriptSignal<T>;
+	/** The reason we DON'T allow you to use `Parameters<T>` here is because you can't trust data from the client. Please type-check and sanity-check all values received from the client. E.g. if you are expecting a number from the client, you should check whether a given value is a number and you might also want to make sure it isn't a `NaN` value. In code, this looks like:
+	 * @example
+	 * (new Instance("RemoteEvent") as RemoteEvent<(num: number) => void>).OnServerEvent.Connect((plr, num) => {
+	 * 	if (typeIs(num, "number") && num === num) {
+	 * 		print(`Yay! Valid number: ${num}`);
+	 * 	} else {
+	 * 		print(`Bad argument received from ${plr.Name}! Exploit or bug?`);
+	 * 	}
+	 * });
+	 */
+	readonly OnServerEvent: RBXScriptSignal<(player: Player, ...args: Array<unknown>) => void>;
+	FireAllClients(this: RemoteEvent, ...args: Parameters<T>): void;
+	FireClient(this: RemoteEvent, player: Player, ...args: Parameters<T>): void;
+	FireServer(this: RemoteEvent, ...args: Parameters<T>): void;
 }
 
-interface RemoteFunction extends Instance {
-	OnClientInvoke: (...arguments: Array<any>) => void;
-	OnServerInvoke: (player: Player, ...arguments: Array<unknown>) => void;
-	InvokeClient(this: RemoteFunction, player: Player, ...arguments: Array<any>): unknown;
-	InvokeServer<R>(this: RemoteFunction, ...arguments: Array<unknown>): R;
+interface RemoteFunction<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
+	OnClientInvoke: T;
+	/** The reason we DON'T allow you to use `Parameters<T>` here is because you can't trust data from the client. Please type-check and sanity-check all values received from the client. E.g. if you are expecting a number from the client, you should check whether a given value is a number and you might also want to make sure it isn't a `NaN` value. In code, this looks like:
+	 * @example
+	 * (new Instance("RemoteFunction") as RemoteFunction<(num: number) => void>).OnServerInvoke = (plr, num) => {
+	 * 	if (typeIs(num, "number") && num === num) {
+	 * 		print(`Yay! Valid number: ${num}`);
+	 * 	} else {
+	 * 		print(`Bad argument received from ${plr.Name}! Exploit or bug?`);
+	 * 	}
+	 * };
+	 */
+	OnServerInvoke: (player: Player, ...args: Array<unknown>) => void;
+	InvokeClient(this: RemoteFunction, player: Player, ...args: Parameters<T>): unknown;
+	InvokeServer(this: RemoteFunction, ...args: Parameters<T>): ReturnType<T>;
 }
 
 interface RunService extends Instance {

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -77,12 +77,12 @@ interface BillboardGui extends LayerCollector {
 	PlayerToHideFrom: Player | undefined;
 }
 
-interface BindableEvent<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
+interface BindableEvent<T extends Callback = Callback> extends Instance {
 	readonly Event: RBXScriptSignal<T>;
 	Fire(this: BindableEvent, ...args: Parameters<T>): void;
 }
 
-interface BindableFunction<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
+interface BindableFunction<T extends Callback = Callback> extends Instance {
 	OnInvoke: T;
 	Invoke(this: BindableFunction, ...args: Parameters<T>): ReturnType<T>;
 }
@@ -573,7 +573,7 @@ interface PolicyService extends Instance {
 	GetPolicyInfoForPlayerAsync(this: PolicyService, player: Player): PolicyInfo;
 }
 
-interface RemoteEvent<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
+interface RemoteEvent<T extends Callback = Callback> extends Instance {
 	readonly OnClientEvent: RBXScriptSignal<T>;
 	/** The reason we DON'T allow you to use `Parameters<T>` here is because you can't trust data from the client. Please type-check and sanity-check all values received from the client. E.g. if you are expecting a number from the client, you should check whether the received value is indeed a number and you might also want to make sure it isn't a `NaN` value. See example code:
 	 * ```ts
@@ -592,7 +592,7 @@ interface RemoteEvent<T extends (...args: Array<any>) => void = (...args: Array<
 	FireServer(this: RemoteEvent, ...args: Parameters<T>): void;
 }
 
-interface RemoteFunction<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
+interface RemoteFunction<T extends Callback = Callback> extends Instance {
 	OnClientInvoke: T;
 	/** The reason we DON'T allow you to use `Parameters<T>` here is because you can't trust data from the client. Please type-check and sanity-check all values received from the client. E.g. if you are expecting a number from the client, you should check whether the received value is indeed a number and you might also want to make sure it isn't a `NaN` value. See example code:
 	 * ```ts

--- a/include/generated/None.d.ts
+++ b/include/generated/None.d.ts
@@ -36,6 +36,7 @@ interface Services {
 	Players: Players;
 	PolicyService: PolicyService;
 	ReplicatedFirst: ReplicatedFirst;
+	ReplicatedScriptService: ReplicatedScriptService;
 	ReplicatedStorage: ReplicatedStorage;
 	RunService: RunService;
 	ServerScriptService: ServerScriptService;
@@ -328,7 +329,7 @@ interface Instances extends Services, CreatableInstances, AbstractInstances {
  */
 interface Instance {
 	/** The string representing the class this Instance belongs to. `classIs()` can be used to check if this instance belongs to a specific class, ignoring class inheritance. */
-	readonly ClassName: "ABTestService" | "Accessory" | "Accoutrement" | "AdService" | "AdvancedDragger" | "AlignOrientation" | "AlignPosition" | "AnalysticsSettings" | "AnalyticsService" | "AngularVelocity" | "Animation" | "AnimationController" | "AnimationTrack" | "Animator" | "AppStorageService" | "ArcHandles" | "AssetManagerService" | "AssetService" | "Atmosphere" | "Attachment" | "Backpack" | "BadgeService" | "BallSocketConstraint" | "Beam" | "BillboardGui" | "BinaryStringValue" | "BindableEvent" | "BindableFunction" | "BlockMesh" | "BloomEffect" | "BlurEffect" | "BodyAngularVelocity" | "BodyColors" | "BodyForce" | "BodyGyro" | "BodyPosition" | "BodyThrust" | "BodyVelocity" | "BoolValue" | "BoxHandleAdornment" | "BrickColorValue" | "BrowserService" | "BulkImportService" | "CacheableContentProvider" | "Camera" | "CFrameValue" | "ChangeHistoryService" | "CharacterMesh" | "Chat" | "ChorusSoundEffect" | "ClickDetector" | "ClientReplicator" | "ClusterPacketCache" | "CollectionService" | "Color3Value" | "ColorCorrectionEffect" | "CompressorSoundEffect" | "ConeHandleAdornment" | "Configuration" | "ContentProvider" | "ContextActionService" | "ControllerService" | "CookiesService" | "CoreGui" | "CorePackages" | "CoreScript" | "CoreScriptSyncService" | "CornerWedgePart" | "CSGDictionaryService" | "CustomEvent" | "CustomEventReceiver" | "CylinderHandleAdornment" | "CylinderMesh" | "CylindricalConstraint" | "DataModel" | "DataModelSession" | "DataStorePages" | "DataStoreService" | "Debris" | "DebuggerBreakpoint" | "DebuggerManager" | "DebuggerWatch" | "DebugSettings" | "Decal" | "DepthOfFieldEffect" | "Dialog" | "DialogChoice" | "DistortionSoundEffect" | "DockWidgetPluginGui" | "DoubleConstrainedValue" | "DraftsService" | "Dragger" | "EchoSoundEffect" | "EmotesPages" | "EqualizerSoundEffect" | "EventIngestService" | "Explosion" | "File" | "FileMesh" | "Fire" | "Flag" | "FlagStand" | "FlagStandService" | "FlangeSoundEffect" | "FloorWire" | "FlyweightService" | "Folder" | "ForceField" | "Frame" | "FriendPages" | "FriendService" | "FunctionalTest" | "GamepadService" | "GamePassService" | "GameSettings" | "Geometry" | "GlobalDataStore" | "GlobalSettings" | "Glue" | "GoogleAnalyticsConfiguration" | "GroupService" | "GuidRegistryService" | "GuiMain" | "GuiService" | "Handles" | "HapticService" | "Hat" | "HingeConstraint" | "Hint" | "Hole" | "Hopper" | "HopperBin" | "HttpRbxApiService" | "HttpRequest" | "HttpService" | "Humanoid" | "HumanoidController" | "HumanoidDescription" | "ImageButton" | "ImageHandleAdornment" | "ImageLabel" | "InputObject" | "InsertService" | "InstanceAdornment" | "IntConstrainedValue" | "IntValue" | "InventoryPages" | "JointsService" | "KeyboardService" | "Keyframe" | "KeyframeMarker" | "KeyframeSequence" | "KeyframeSequenceProvider" | "LanguageService" | "Lighting" | "LineForce" | "LineHandleAdornment" | "LocalizationService" | "LocalizationTable" | "LocalScript" | "LocalStorageService" | "LoginService" | "LogService" | "LuaSettings" | "LuaWebService" | "ManualGlue" | "ManualWeld" | "MarketplaceService" | "MemStorageConnection" | "MemStorageService" | "MeshContentProvider" | "MeshPart" | "Message" | "MessagingService" | "Model" | "ModuleScript" | "Motor" | "Motor6D" | "MotorFeature" | "Mouse" | "MouseService" | "MultipleDocumentInterfaceInstance" | "NegateOperation" | "NetworkClient" | "NetworkMarker" | "NetworkServer" | "NetworkSettings" | "NoCollisionConstraint" | "NonReplicatedCSGDictionaryService" | "NotificationService" | "NumberValue" | "ObjectValue" | "OrderedDataStore" | "PackageLink" | "PackageService" | "Pants" | "ParabolaAdornment" | "Part" | "ParticleEmitter" | "PartOperation" | "PartOperationAsset" | "Path" | "PathfindingService" | "PermissionsService" | "PhysicsService" | "PhysicsSettings" | "PitchShiftSoundEffect" | "Platform" | "Player" | "PlayerEmulatorService" | "PlayerGui" | "PlayerMouse" | "Players" | "PlayerScripts" | "Plugin" | "PluginAction" | "PluginDebugService" | "PluginDragEvent" | "PluginGuiService" | "PluginManager" | "PluginMenu" | "PluginMouse" | "PluginToolbar" | "PluginToolbarButton" | "PointLight" | "PointsService" | "PolicyService" | "Pose" | "PrismaticConstraint" | "QWidgetPluginGui" | "RayValue" | "RbxAnalyticsService" | "ReflectionMetadata" | "ReflectionMetadataCallbacks" | "ReflectionMetadataClass" | "ReflectionMetadataClasses" | "ReflectionMetadataEnum" | "ReflectionMetadataEnumItem" | "ReflectionMetadataEnums" | "ReflectionMetadataEvents" | "ReflectionMetadataFunctions" | "ReflectionMetadataItem" | "ReflectionMetadataMember" | "ReflectionMetadataProperties" | "ReflectionMetadataYieldFunctions" | "RemoteEvent" | "RemoteFunction" | "RenderingTest" | "RenderSettings" | "ReplicatedFirst" | "ReplicatedStorage" | "ReverbSoundEffect" | "RobloxPluginGuiService" | "RobloxReplicatedStorage" | "RocketPropulsion" | "RodConstraint" | "RopeConstraint" | "Rotate" | "RotateP" | "RotateV" | "RunningAverageItemDouble" | "RunningAverageItemInt" | "RunningAverageTimeIntervalItem" | "RunService" | "RuntimeScriptService" | "ScreenGui" | "Script" | "ScriptContext" | "ScriptDebugger" | "ScriptService" | "ScrollingFrame" | "Seat" | "Selection" | "SelectionBox" | "SelectionPartLasso" | "SelectionPointLasso" | "SelectionSphere" | "ServerReplicator" | "ServerScriptService" | "ServerStorage" | "SessionService" | "Shirt" | "ShirtGraphic" | "SkateboardController" | "SkateboardPlatform" | "Skin" | "Sky" | "Smoke" | "Snap" | "SocialService" | "SolidModelContentProvider" | "Sound" | "SoundGroup" | "SoundService" | "Sparkles" | "SpawnerService" | "SpawnLocation" | "SpecialMesh" | "SphereHandleAdornment" | "SpotLight" | "SpringConstraint" | "StandalonePluginScripts" | "StandardPages" | "StarterCharacterScripts" | "StarterGear" | "StarterGui" | "StarterPack" | "StarterPlayer" | "StarterPlayerScripts" | "Stats" | "Status" | "StopWatchReporter" | "StringValue" | "Studio" | "StudioData" | "StudioService" | "StudioTheme" | "SunRaysEffect" | "SurfaceAppearance" | "SurfaceGui" | "SurfaceLight" | "SurfaceSelection" | "TaskScheduler" | "Team" | "Teams" | "TeleportService" | "Terrain" | "TerrainRegion" | "TestService" | "TextBox" | "TextButton" | "TextFilterResult" | "TextLabel" | "TextService" | "Texture" | "ThirdPartyUserService" | "TimerService" | "Tool" | "Torque" | "TotalCountTimeIntervalItem" | "TouchInputService" | "TouchTransmitter" | "Trail" | "Translator" | "TremoloSoundEffect" | "TrussPart" | "Tween" | "TweenService" | "UGCValidationService" | "UIAspectRatioConstraint" | "UIGradient" | "UIGridLayout" | "UIInlineLayout" | "UIListLayout" | "UIPadding" | "UIPageLayout" | "UIScale" | "UISizeConstraint" | "UITableLayout" | "UITextSizeConstraint" | "UnionOperation" | "UserGameSettings" | "UserInputService" | "UserService" | "UserSettings" | "UserStorageService" | "Vector3Value" | "VectorForce" | "VehicleController" | "VehicleSeat" | "VelocityMotor" | "VersionControlService" | "VideoFrame" | "ViewportFrame" | "VirtualInputManager" | "VirtualUser" | "Visit" | "VRService" | "WedgePart" | "Weld" | "WeldConstraint" | "Workspace" | "WorldModel";
+	readonly ClassName: "ABTestService" | "Accessory" | "Accoutrement" | "AdService" | "AdvancedDragger" | "AlignOrientation" | "AlignPosition" | "AnalysticsSettings" | "AnalyticsService" | "AngularVelocity" | "Animation" | "AnimationController" | "AnimationTrack" | "Animator" | "AppStorageService" | "ArcHandles" | "AssetManagerService" | "AssetService" | "Atmosphere" | "Attachment" | "Backpack" | "BadgeService" | "BallSocketConstraint" | "Beam" | "BillboardGui" | "BinaryStringValue" | "BindableEvent" | "BindableFunction" | "BlockMesh" | "BloomEffect" | "BlurEffect" | "BodyAngularVelocity" | "BodyColors" | "BodyForce" | "BodyGyro" | "BodyPosition" | "BodyThrust" | "BodyVelocity" | "BoolValue" | "BoxHandleAdornment" | "BrickColorValue" | "BrowserService" | "BulkImportService" | "CacheableContentProvider" | "Camera" | "CFrameValue" | "ChangeHistoryService" | "CharacterMesh" | "Chat" | "ChorusSoundEffect" | "ClickDetector" | "ClientReplicator" | "ClusterPacketCache" | "CollectionService" | "Color3Value" | "ColorCorrectionEffect" | "CompressorSoundEffect" | "ConeHandleAdornment" | "Configuration" | "ContentProvider" | "ContextActionService" | "ControllerService" | "CookiesService" | "CoreGui" | "CorePackages" | "CoreScript" | "CoreScriptSyncService" | "CornerWedgePart" | "CSGDictionaryService" | "CustomEvent" | "CustomEventReceiver" | "CylinderHandleAdornment" | "CylinderMesh" | "CylindricalConstraint" | "DataModel" | "DataModelSession" | "DataStorePages" | "DataStoreService" | "Debris" | "DebuggerBreakpoint" | "DebuggerManager" | "DebuggerWatch" | "DebugSettings" | "Decal" | "DepthOfFieldEffect" | "Dialog" | "DialogChoice" | "DistortionSoundEffect" | "DockWidgetPluginGui" | "DoubleConstrainedValue" | "DraftsService" | "Dragger" | "EchoSoundEffect" | "EmotesPages" | "EqualizerSoundEffect" | "EventIngestService" | "Explosion" | "File" | "FileMesh" | "Fire" | "Flag" | "FlagStand" | "FlagStandService" | "FlangeSoundEffect" | "FloorWire" | "FlyweightService" | "Folder" | "ForceField" | "Frame" | "FriendPages" | "FriendService" | "FunctionalTest" | "GamepadService" | "GamePassService" | "GameSettings" | "Geometry" | "GlobalDataStore" | "GlobalSettings" | "Glue" | "GoogleAnalyticsConfiguration" | "GroupService" | "GuidRegistryService" | "GuiMain" | "GuiService" | "Handles" | "HapticService" | "Hat" | "HingeConstraint" | "Hint" | "Hole" | "Hopper" | "HopperBin" | "HttpRbxApiService" | "HttpRequest" | "HttpService" | "Humanoid" | "HumanoidController" | "HumanoidDescription" | "ImageButton" | "ImageHandleAdornment" | "ImageLabel" | "InputObject" | "InsertService" | "InstanceAdornment" | "IntConstrainedValue" | "IntValue" | "InventoryPages" | "JointsService" | "KeyboardService" | "Keyframe" | "KeyframeMarker" | "KeyframeSequence" | "KeyframeSequenceProvider" | "LanguageService" | "Lighting" | "LineForce" | "LineHandleAdornment" | "LocalizationService" | "LocalizationTable" | "LocalScript" | "LocalStorageService" | "LoginService" | "LogService" | "LuaSettings" | "LuaWebService" | "ManualGlue" | "ManualWeld" | "MarketplaceService" | "MemStorageConnection" | "MemStorageService" | "MeshContentProvider" | "MeshPart" | "Message" | "MessagingService" | "Model" | "ModuleScript" | "Motor" | "Motor6D" | "MotorFeature" | "Mouse" | "MouseService" | "MultipleDocumentInterfaceInstance" | "NegateOperation" | "NetworkClient" | "NetworkMarker" | "NetworkServer" | "NetworkSettings" | "NoCollisionConstraint" | "NonReplicatedCSGDictionaryService" | "NotificationService" | "NumberValue" | "ObjectValue" | "OrderedDataStore" | "PackageLink" | "PackageService" | "Pants" | "ParabolaAdornment" | "Part" | "ParticleEmitter" | "PartOperation" | "PartOperationAsset" | "Path" | "PathfindingService" | "PermissionsService" | "PhysicsService" | "PhysicsSettings" | "PitchShiftSoundEffect" | "Platform" | "Player" | "PlayerEmulatorService" | "PlayerGui" | "PlayerMouse" | "Players" | "PlayerScripts" | "Plugin" | "PluginAction" | "PluginDebugService" | "PluginDragEvent" | "PluginGuiService" | "PluginManager" | "PluginMenu" | "PluginMouse" | "PluginToolbar" | "PluginToolbarButton" | "PointLight" | "PointsService" | "PolicyService" | "Pose" | "PrismaticConstraint" | "QWidgetPluginGui" | "RayValue" | "RbxAnalyticsService" | "ReflectionMetadata" | "ReflectionMetadataCallbacks" | "ReflectionMetadataClass" | "ReflectionMetadataClasses" | "ReflectionMetadataEnum" | "ReflectionMetadataEnumItem" | "ReflectionMetadataEnums" | "ReflectionMetadataEvents" | "ReflectionMetadataFunctions" | "ReflectionMetadataItem" | "ReflectionMetadataMember" | "ReflectionMetadataProperties" | "ReflectionMetadataYieldFunctions" | "RemoteEvent" | "RemoteFunction" | "RenderingTest" | "RenderSettings" | "ReplicatedFirst" | "ReplicatedScriptService" | "ReplicatedStorage" | "ReverbSoundEffect" | "RobloxPluginGuiService" | "RobloxReplicatedStorage" | "RocketPropulsion" | "RodConstraint" | "RopeConstraint" | "Rotate" | "RotateP" | "RotateV" | "RunningAverageItemDouble" | "RunningAverageItemInt" | "RunningAverageTimeIntervalItem" | "RunService" | "RuntimeScriptService" | "ScreenGui" | "Script" | "ScriptContext" | "ScriptDebugger" | "ScriptService" | "ScrollingFrame" | "Seat" | "Selection" | "SelectionBox" | "SelectionPartLasso" | "SelectionPointLasso" | "SelectionSphere" | "ServerReplicator" | "ServerScriptService" | "ServerStorage" | "SessionService" | "Shirt" | "ShirtGraphic" | "SkateboardController" | "SkateboardPlatform" | "Skin" | "Sky" | "Smoke" | "Snap" | "SocialService" | "SolidModelContentProvider" | "Sound" | "SoundGroup" | "SoundService" | "Sparkles" | "SpawnerService" | "SpawnLocation" | "SpecialMesh" | "SphereHandleAdornment" | "SpotLight" | "SpringConstraint" | "StandalonePluginScripts" | "StandardPages" | "StarterCharacterScripts" | "StarterGear" | "StarterGui" | "StarterPack" | "StarterPlayer" | "StarterPlayerScripts" | "Stats" | "Status" | "StopWatchReporter" | "StringValue" | "Studio" | "StudioData" | "StudioService" | "StudioTheme" | "SunRaysEffect" | "SurfaceAppearance" | "SurfaceGui" | "SurfaceLight" | "SurfaceSelection" | "TaskScheduler" | "Team" | "Teams" | "TeleportService" | "Terrain" | "TerrainRegion" | "TestService" | "TextBox" | "TextButton" | "TextFilterResult" | "TextLabel" | "TextService" | "Texture" | "ThirdPartyUserService" | "TimerService" | "Tool" | "Torque" | "TotalCountTimeIntervalItem" | "TouchInputService" | "TouchTransmitter" | "Trail" | "Translator" | "TremoloSoundEffect" | "TrussPart" | "Tween" | "TweenService" | "UGCValidationService" | "UIAspectRatioConstraint" | "UIGradient" | "UIGridLayout" | "UIInlineLayout" | "UIListLayout" | "UIPadding" | "UIPageLayout" | "UIScale" | "UISizeConstraint" | "UITableLayout" | "UITextSizeConstraint" | "UnionOperation" | "UserGameSettings" | "UserInputService" | "UserService" | "UserSettings" | "UserStorageService" | "Vector3Value" | "VectorForce" | "VehicleController" | "VehicleSeat" | "VelocityMotor" | "VersionControlService" | "VideoFrame" | "ViewportFrame" | "VirtualInputManager" | "VirtualUser" | "Visit" | "VRService" | "WedgePart" | "Weld" | "WeldConstraint" | "Workspace" | "WorldModel";
 	/** Determines if an `Instance` can be cloned using [Instance.Clone](https://developer.roblox.com/api-reference/function/Instance/Clone) or saved to file.
 	 * 
 	 * This property determines whether an object should be included when the game is published or saved, or when [Instance.Clone](https://developer.roblox.com/api-reference/function/Instance/Clone) is called on one of the objects ancestors. Calling Clone directly on an object will return nil if the cloned object is not archivable. Copying an object in Studio (using the 'Duplicate' or 'Copy' options) will ignore the Archivable property and set Archivable to true for the copy.
@@ -1038,7 +1039,7 @@ interface AnimationController extends Instance {
 }
 
 /** Controls the playback of an animation on a `Humanoid` or `AnimationController`. This object cannot be created, instead it is returned by the [Humanoid.LoadAnimation](https://developer.roblox.com/api-reference/function/Humanoid/LoadAnimation) method. */
-interface AnimationTrack {
+interface AnimationTrack extends Instance {
 	/** The string representing the class this Instance belongs to. `classIs()` can be used to check if this instance belongs to a specific class, ignoring class inheritance. */
 	readonly ClassName: "AnimationTrack";
 	/** The `Animation` object that was used to create this `AnimationTrack`. To create an `AnimationTrack` the developer must load an `Animation` object onto a `Humanoid` or `AnimationController` using the [Humanoid.LoadAnimation](https://developer.roblox.com/api-reference/function/Humanoid/LoadAnimation) method.
@@ -2438,26 +2439,26 @@ interface Beam extends Instance {
 }
 
 /** **Note:** If a Table is passed as an argument to a BindableEvent it must be an array without missing entries or have string keys, not a mixture, or else the string keys will be lost. Allows events defined in one script to be subscribed to by another script. However, please note that BindableEvents do not allow for communication between the server and client. If you are looking for this functionality use `RemoteEvent`. */
-interface BindableEvent extends Instance {
+interface BindableEvent<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
 	/** The string representing the class this Instance belongs to. `classIs()` can be used to check if this instance belongs to a specific class, ignoring class inheritance. */
 	readonly ClassName: "BindableEvent";
 	/** Calling this method will fire the "Event" event. This function does not yield, even no script has connected to the "Event" event and even if a connected function yields. There are limitations on the values that can be sent as arguments; see the code samples */
-	Fire(this: BindableEvent, ...arguments: Array<unknown>): void;
+	Fire(this: BindableEvent, ...args: Parameters<T>): void;
 	/** This event is fired when any script calls the Fire method of the BindableEvent. */
-	readonly Event: RBXScriptSignal<(...arguments: Array<any>) => void>;
+	readonly Event: RBXScriptSignal<T>;
 }
 
 /** A BindableFunction is a Roblox object that allows you to give access to functions to external scripts. Functions put in BindableFunctions will not be replicated, therefore making it impossible to use these objects to pass functions between scripts. Functions are invoked through [BindableFunction.Invoke](https://developer.roblox.com/api-reference/function/BindableFunction/Invoke), which calls [BindableFunction.OnInvoke](https://developer.roblox.com/api-reference/callback/BindableFunction/OnInvoke). */
-interface BindableFunction extends Instance {
+interface BindableFunction<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
 	/** The string representing the class this Instance belongs to. `classIs()` can be used to check if this instance belongs to a specific class, ignoring class inheritance. */
 	readonly ClassName: "BindableFunction";
 	/** Invoke will call the OnInvoke callback and return any values that were returned by the callback (if any). If the OnInvoke callback is not set, this method will yield until one is set. If OnInvoke yields, this method will also yield. There are limitations on the values that can be sent as arguments; see the code samples. */
-	Invoke(this: BindableFunction, ...arguments: Array<unknown>): Array<unknown>;
+	Invoke(this: BindableFunction, ...args: Parameters<T>): ReturnType<T>;
 	/** This callback can be set multiple times, but cannot be called directly. It is called when the [BindableFunction.Invoke](https://developer.roblox.com/api-reference/function/BindableFunction/Invoke) method is called, using the same arguments as parameters.
 	 * 
 	 * There are limitations on the valid parameters this callback can return (see the code samples to learn more).
 	 */
-	OnInvoke: (...arguments: Array<unknown>) => any;
+	OnInvoke: T;
 }
 
 /** BodyMover is the abstract base class for the set of legacy objects that exert forces to `BasePart`s in different ways. In general, the subclasses of BodyMover can be placed into one of two categories based on the type of force(s) they exert:
@@ -12841,6 +12842,8 @@ interface PartOperation extends TriangleMeshPart {
 	readonly ClassName: "NegateOperation" | "PartOperation" | "UnionOperation";
 	/** [NO DOCUMENTATION] */
 	readonly RenderFidelity: Enum.RenderFidelity;
+	/** [NO DOCUMENTATION] */
+	readonly SmoothingAngle: number;
 	/** The number of polygons in this solid model. This value will always be &lt;= 5000.
 	 * 	
 	 * The number of polygons in this solid model. This value will always be &lt;= 5000.
@@ -15000,7 +15003,7 @@ interface SunRaysEffect extends PostEffect {
  * 
  * If you need the result of the call, you should use a `RemoteFunction` instead. Otherwise a remote event is recommended since it will minimize network traffic/latency and won't yield the script to wait for a response. See [Remote Functions and Events](https://developer.roblox.com/search#stq=Remote%20Functions%20and%20Events) for more info.
  */
-interface RemoteEvent extends Instance {
+interface RemoteEvent<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
 	/** The string representing the class this Instance belongs to. `classIs()` can be used to check if this instance belongs to a specific class, ignoring class inheritance. */
 	readonly ClassName: "RemoteEvent";
 	/** The FireAllClients function fires the [RemoteEvent.OnClientEvent](https://developer.roblox.com/api-reference/event/RemoteEvent/OnClientEvent) event for each client.
@@ -15021,7 +15024,7 @@ interface RemoteEvent extends Instance {
 	 * @param arguments The arguments that will be passed to all `RemoteEvent/OnClientEvent` methods.
 	 * @returns void
 	 */
-	FireAllClients(this: RemoteEvent, ...arguments: Array<unknown>): void;
+	FireAllClients(this: RemoteEvent, ...args: Parameters<T>): void;
 	/** Fires [RemoteEvent.OnClientEvent](https://developer.roblox.com/api-reference/event/RemoteEvent/OnClientEvent) for the specified player.  Only [connections][1] in `LocalScript`s that are running on the specified player's client will fire. This varies from the RemoteFunction class which will queue requests.
 	 * 
 	 * Since this function is used to communicate from the server to the client, it will only work when used in a `Script`.
@@ -15043,7 +15046,7 @@ interface RemoteEvent extends Instance {
 	 * @param arguments The arguments passed to the `RemoteEvent/OnClientEvent` method.
 	 * @returns void
 	 */
-	FireClient(this: RemoteEvent, player: Player, ...arguments: Array<unknown>): void;
+	FireClient(this: RemoteEvent, player: Player, ...args: Parameters<T>): void;
 	/** The FireServer event fires the [RemoteEvent.OnServerEvent](https://developer.roblox.com/api-reference/event/RemoteEvent/OnServerEvent) event on the server using the arguments specified with an additional player argument at the beginning.
 	 * 
 	 * Since this function is used to communicate from the client to the server, it will only work when used in a `LocalScript`.
@@ -15056,7 +15059,7 @@ interface RemoteEvent extends Instance {
 	 * @param arguments The arguments passed to the `RemoteEvent/OnServerEvent` method.
 	 * @returns void
 	 */
-	FireServer(this: RemoteEvent, ...arguments: Array<unknown>): void;
+	FireServer(this: RemoteEvent, ...args: Parameters<T>): void;
 	/** The OnClientEvent event fires listening functions in `LocalScript` when either [RemoteEvent.FireClient](https://developer.roblox.com/api-reference/function/RemoteEvent/FireClient) or [RemoteEvent.FireAllClients](https://developer.roblox.com/api-reference/function/RemoteEvent/FireAllClients) is fired by the server from a `Script`.
 	 * 
 	 * This is used to retrieve remote events fired by the server and intended for the client. This event is in place to provide a method for communicating between the server and client, which is well documented in [this][1] article. This event retrieves remote events fired by the server to the client.
@@ -15065,7 +15068,7 @@ interface RemoteEvent extends Instance {
 	 * 
 	 * [1]: https://developer.roblox.com/articles/Remote-Functions-and-Events
 	 */
-	readonly OnClientEvent: RBXScriptSignal<(...arguments: Array<any>) => void>;
+	readonly OnClientEvent: RBXScriptSignal<T>;
 	/** Fires listening functions in `Script` when [RemoteEvent.FireServer](https://developer.roblox.com/api-reference/function/RemoteEvent/FireServer) is called from a `LocalScript`.
 	 * 
 	 * This is used to retrieve remote events fired by the client and intended for the server. This event is in place to provide a method for communicating between the client and server, which is well documented in [this][1] article. This event retrieves remote events fired by the client to the server.
@@ -15074,7 +15077,7 @@ interface RemoteEvent extends Instance {
 	 * 
 	 * [1]: https://developer.roblox.com/articles/Remote-Functions-and-Events
 	 */
-	readonly OnServerEvent: RBXScriptSignal<(player: Player, ...arguments: Array<unknown>) => void>;
+	readonly OnServerEvent: RBXScriptSignal<(player: Player, ...args: Array<unknown>) => void>;
 }
 
 /** A **RemoteFunction** is used to create in-game APIs that both the client and the server can use to communicate with each other. Like `BindableFunction`, a RemoteFunction can be invoked (called) to do a certain action and return the results.
@@ -15109,7 +15112,7 @@ interface RemoteFunction extends Instance {
 	 * @param arguments The arguments passed to the `RemoteEvent/OnClientInvoke` method.
 	 * @returns Values returned by `RemoteFunction/OnClientInvoke`.
 	 */
-	InvokeClient(this: RemoteFunction, player: Player, ...arguments: Array<any>): unknown;
+	InvokeClient(this: RemoteFunction, player: Player, ...args: Array<any>): unknown;
 	/** Clients invoking the server is often used because the server either has access to information the client does not, or the client is requesting a game action that only the server can perform. When invoked, this calls the method bound to the RemoteFunction by [RemoteFunction.OnServerInvoke](https://developer.roblox.com/api-reference/callback/RemoteFunction/OnServerInvoke). Use from a `LocalScript`.
 	 * 
 	 * If the result is not needed then it is recommended to use a [RemoteEvent.FireServer](https://developer.roblox.com/api-reference/function/RemoteEvent/FireServer) instead, as its call is asynchronous and doesn't need to wait for a response to continue execution.
@@ -15126,14 +15129,14 @@ interface RemoteFunction extends Instance {
 	 * @param arguments The arguments passed to the `RemoteEvent/OnServerInvoke` method.
 	 * @returns Values returned by `RemoteFunction/OnServerInvoke`.
 	 */
-	InvokeServer<R>(this: RemoteFunction, ...arguments: Array<unknown>): R;
+	InvokeServer<R>(this: RemoteFunction, ...args: Array<unknown>): R;
 	/** The OnClientInvoke event fires the bound functions in `LocalScript`s when [RemoteFunction.InvokeClient](https://developer.roblox.com/api-reference/function/RemoteFunction/InvokeClient) is called by the server from a `Script`. When the bound function returns, the returned values are sent back to the server.
 	 * 
 	 * This is used to listen to remote functions invoked by the server and intended for the client. This callback is in place to provide a method for communicating between the server and client.
 	 * 
 	 * To fire from the client to the server, you should use [RemoteFunction.InvokeServer](https://developer.roblox.com/api-reference/function/RemoteFunction/InvokeServer) and [RemoteFunction.OnServerInvoke](https://developer.roblox.com/api-reference/callback/RemoteFunction/OnServerInvoke).
 	 */
-	OnClientInvoke: (...arguments: Array<any>) => void;
+	OnClientInvoke: (...args: Array<any>) => void;
 	/** The OnServerInvoke event fires the bound functions in `Script`s when [RemoteFunction.InvokeServer](https://developer.roblox.com/api-reference/function/RemoteFunction/InvokeServer) is called by the server from a `LocalScript`. When the bound function returns, the returned values are sent back to the client.
 	 * 
 	 * This is used to retrieve remote events fired by the client and intended for the server. This event is in place to provide a method for communicating between the client and server, which is well documented in [this][1] article.
@@ -15148,7 +15151,7 @@ interface RemoteFunction extends Instance {
 	 * 
 	 *  - Only one function can be assigned to OnServerInvoke at a time. If multiple functions are assigned, only the last function to be assigned will be used.
 	 */
-	OnServerInvoke: (player: Player, ...arguments: Array<unknown>) => void;
+	OnServerInvoke: (player: Player, ...args: Array<unknown>) => void;
 }
 
 /** A container whose contents are replicated to all clients (but not back to the server) first before anything else.
@@ -15181,6 +15184,11 @@ interface ReplicatedFirst extends Instance {
 	 * It is advised to not remove the default loading screen unless the developer wishes to display their own loading screen as an alternative. If the default screen is removed without replacement users will be able to see geometry loading in the background.
 	 */
 	RemoveDefaultLoadingScreen(this: ReplicatedFirst): void;
+}
+
+interface ReplicatedScriptService extends Instance {
+	/** The string representing the class this Instance belongs to. `classIs()` can be used to check if this instance belongs to a specific class, ignoring class inheritance. */
+	readonly ClassName: "ReplicatedScriptService";
 }
 
 /** Complex games often require a range of assets that are held in storage until they're required. **ReplicatedStorage** is a container whose contents are replicated to all connected clients, allowing such objects to be stored until needed. ReplicatedStorage is also an ideal location for [RemoteFunctions](https://developer.roblox.com/api-reference/class/RemoteFunction) and [RemoteEvents](https://developer.roblox.com/api-reference/class/RemoteEvent) since they can be found on both the client and server.

--- a/include/generated/None.d.ts
+++ b/include/generated/None.d.ts
@@ -15084,7 +15084,7 @@ interface RemoteEvent<T extends (...args: Array<any>) => void = (...args: Array<
  * 
  * If the result is **not** needed, we recommend that you use a `RemoteEvent` instead, since its call is asynchronous and doesn't need to wait for a response to continue execution. See `Remote Functions and Events` for more info.
  */
-interface RemoteFunction extends Instance {
+interface RemoteFunction<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> extends Instance {
 	/** The string representing the class this Instance belongs to. `classIs()` can be used to check if this instance belongs to a specific class, ignoring class inheritance. */
 	readonly ClassName: "RemoteFunction";
 	/** Calls the method bound to the RemoteFunction by [RemoteFunction.OnClientInvoke](https://developer.roblox.com/api-reference/callback/RemoteFunction/OnClientInvoke) for the given `Player`. Use from a `Script`.
@@ -15112,7 +15112,7 @@ interface RemoteFunction extends Instance {
 	 * @param arguments The arguments passed to the `RemoteEvent/OnClientInvoke` method.
 	 * @returns Values returned by `RemoteFunction/OnClientInvoke`.
 	 */
-	InvokeClient(this: RemoteFunction, player: Player, ...args: Array<any>): unknown;
+	InvokeClient(this: RemoteFunction, player: Player, ...args: Parameters<T>): unknown;
 	/** Clients invoking the server is often used because the server either has access to information the client does not, or the client is requesting a game action that only the server can perform. When invoked, this calls the method bound to the RemoteFunction by [RemoteFunction.OnServerInvoke](https://developer.roblox.com/api-reference/callback/RemoteFunction/OnServerInvoke). Use from a `LocalScript`.
 	 * 
 	 * If the result is not needed then it is recommended to use a [RemoteEvent.FireServer](https://developer.roblox.com/api-reference/function/RemoteEvent/FireServer) instead, as its call is asynchronous and doesn't need to wait for a response to continue execution.
@@ -15129,14 +15129,14 @@ interface RemoteFunction extends Instance {
 	 * @param arguments The arguments passed to the `RemoteEvent/OnServerInvoke` method.
 	 * @returns Values returned by `RemoteFunction/OnServerInvoke`.
 	 */
-	InvokeServer<R>(this: RemoteFunction, ...args: Array<unknown>): R;
+	InvokeServer(this: RemoteFunction, ...args: Parameters<T>): ReturnType<T>;
 	/** The OnClientInvoke event fires the bound functions in `LocalScript`s when [RemoteFunction.InvokeClient](https://developer.roblox.com/api-reference/function/RemoteFunction/InvokeClient) is called by the server from a `Script`. When the bound function returns, the returned values are sent back to the server.
 	 * 
 	 * This is used to listen to remote functions invoked by the server and intended for the client. This callback is in place to provide a method for communicating between the server and client.
 	 * 
 	 * To fire from the client to the server, you should use [RemoteFunction.InvokeServer](https://developer.roblox.com/api-reference/function/RemoteFunction/InvokeServer) and [RemoteFunction.OnServerInvoke](https://developer.roblox.com/api-reference/callback/RemoteFunction/OnServerInvoke).
 	 */
-	OnClientInvoke: (...args: Array<any>) => void;
+	OnClientInvoke: T;
 	/** The OnServerInvoke event fires the bound functions in `Script`s when [RemoteFunction.InvokeServer](https://developer.roblox.com/api-reference/function/RemoteFunction/InvokeServer) is called by the server from a `LocalScript`. When the bound function returns, the returned values are sent back to the client.
 	 * 
 	 * This is used to retrieve remote events fired by the client and intended for the server. This event is in place to provide a method for communicating between the client and server, which is well documented in [this][1] article.

--- a/include/generated/PluginSecurity.d.ts
+++ b/include/generated/PluginSecurity.d.ts
@@ -259,8 +259,6 @@ interface DebugSettings extends Instance {
 	 * Tags: ReadOnly, NotReplicated
 	 */
 	readonly InstanceCount: number;
-	/** Toggles whether or not profiling of the Fmod library (which is responsible for sounds) is enabled. */
-	IsFmodProfilingEnabled: boolean;
 	/** Whether or not a stacktrace is displayed in the output for an error. */
 	IsScriptStackTracingEnabled: boolean;
 	/** Returns the number of internal DataModel jobs actively being processed.

--- a/include/lua.d.ts
+++ b/include/lua.d.ts
@@ -141,8 +141,8 @@ interface LuaMetatable<T> {
 	__eq?: (self: T, other: T) => boolean;
 	__lt?: (self: T, other: T) => boolean;
 	__le?: (self: T, other: T) => boolean;
-	__call?: (self: T, ...arguments: Array<any>) => void;
-	__concat?: (self: T, ...arguments: Array<any>) => string;
+	__call?: (self: T, ...args: Array<any>) => void;
+	__concat?: (self: T, ...args: Array<any>) => string;
 	__tostring?: (self: T) => string;
 	__len?: (self: T) => number;
 	__mode?: "k" | "v" | "kv";

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -51,7 +51,7 @@ type InstanceProperties<T extends Instance> = {
 type WritableInstanceProperties<T extends Instance> = {
 	[K in keyof T]-?: K extends "GetPropertyChangedSignal" | "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
 		? never
-		: T[K] extends RBXScriptSignal | (Callback)
+		: T[K] extends RBXScriptSignal | Callback
 		? never
 		: (<F>() => F extends { [Q in K]: T[K] } ? 1 : 2) extends <F>() => F extends { -readonly [Q in K]: T[K] }
 				? 1

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -583,7 +583,7 @@ interface RBXScriptConnection {
  * When a certain event happens, the Event is fired, calling any listeners that are connected to the Event.
  * An Event may also pass arguments to each listener, to provide extra information about the event that occurred.
  */
-interface RBXScriptSignal<T = ((...args: Array<any>) => void)> {
+interface RBXScriptSignal<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> {
 	/**
 	 * Establishes a function to be called whenever the event is raised.
 	 * Returns a RBXScriptConnection object associated with the connection.

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -42,7 +42,7 @@ type StrictInstances = {
 type InstanceProperties<T extends Instance> = {
 	[K in keyof T]-?: K extends "GetPropertyChangedSignal" | "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
 		? never
-		: T[K] extends RBXScriptSignal | ((...args: Array<any>) => void)
+		: T[K] extends RBXScriptSignal | Callback
 		? never
 		: K;
 }[keyof T];
@@ -51,7 +51,7 @@ type InstanceProperties<T extends Instance> = {
 type WritableInstanceProperties<T extends Instance> = {
 	[K in keyof T]-?: K extends "GetPropertyChangedSignal" | "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
 		? never
-		: T[K] extends RBXScriptSignal | ((...args: Array<any>) => void)
+		: T[K] extends RBXScriptSignal | (Callback)
 		? never
 		: (<F>() => F extends { [Q in K]: T[K] } ? 1 : 2) extends <F>() => F extends { -readonly [Q in K]: T[K] }
 				? 1
@@ -583,7 +583,7 @@ interface RBXScriptConnection {
  * When a certain event happens, the Event is fired, calling any listeners that are connected to the Event.
  * An Event may also pass arguments to each listener, to provide extra information about the event that occurred.
  */
-interface RBXScriptSignal<T extends (...args: Array<any>) => void = (...args: Array<any>) => void> {
+interface RBXScriptSignal<T extends Callback = Callback> {
 	/**
 	 * Establishes a function to be called whenever the event is raised.
 	 * Returns a RBXScriptConnection object associated with the connection.


### PR DESCRIPTION
- Allow `BindableEvent`, `BindableFunction`, `RemoteEvent`, `RemoteFunction` to have type arguments which specify their expected signature
- Change `...arguments` varArgs name to `...args` (best practice, since in regular TS code it will give you are strict-mode related error)
- Make sure that RBXScriptSignal `extends` the same type as it defaults to