### PR TITLE
Add `length: never` field to ArrayLike

### DIFF
--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -31,9 +31,10 @@ interface RegExp {}
  * More generally, `(a: A, b: B, c: C) => R`, where `A`, `B`, and `C` are different function argument types and `R` is
  * the return type.
  *
- * You can use `void` as a return type for functions that do not return anything: `() => void`
+ * You can use `void` as a return type for functions that do not return anything (or for when the return value doesn't matter): `() => void`
  */
 interface Function {
+	/** Not useable in roblox-ts code. We need to have this defined, however, so that function calls work properly within the TS type system. */
 	prototype: never;
 }
 /** **DO NOT USE!** This type only exists because TypeScript requires it! */
@@ -50,6 +51,8 @@ interface ArrayLike<T> {
 	 * Gets the length of the array. This is one higher than the highest index defined in an array.
 	 */
 	size(): number;
+	/** Not useable in roblox-ts code. It is, however, necessary for tuple types, because `length` is written to by the type system in the case of fixed-length arrays (tuples). */
+	length: never;
 	readonly [n: number]: T;
 }
 


### PR DESCRIPTION
Consider the following case:
```ts
type ArrayMembers<A> = A[Exclude<keyof A, keyof Array<any> | "length">];
type B = ArrayMembers<[1, 2, 4]>;
```

In order to properly get all the keys in a tuple (excluding methods) one must `Exclude` from `keyof A` the type `keyof Array<any> | "length"`. This also creates a problem in more complicated types where a given type is proven to extend `Array<any>` but TS still can't validate that it has the `length` member (which in our case, would only exist in the type of fixed-length arrays). In order to circumvent this issue, one must check `keyof T extends "length" ? T["length"]`, however, this only works in TS 3.9 and above and I think only adds unnecessarily to the learning curve for roblox-ts. Hence, I think it is best to add a `length: never` property to the Array type.