### PR TITLE
OriginalInstance type update

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -314,7 +314,7 @@ interface Instance {
 	 * 	(p as Part & ChangedSignal).Changed.Connect(changedPropertyName => {})
 	 * }
 	 */
-	Changed: unknown;
+	readonly Changed: unknown;
 	GetChildren(this: Instance): Array<Instance>;
 	GetDescendants(this: Instance): Array<Instance>;
 
@@ -874,9 +874,9 @@ interface ValueBase extends Instance {
 
 interface Workspace extends WorldRoot {
 	/** Do not use `Workspace.BreakJoints`. Use a for-loop instead */
-	BreakJoints: any;
+	readonly BreakJoints: any;
 	/** Do not use `Workspace.MakeJoints`. Use a for-loop instead */
-	MakeJoints: any;
+	readonly MakeJoints: any;
 	Terrain: Terrain;
 }
 

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -115,6 +115,7 @@ type FunctionArguments<T> = T extends (...args: infer U) => void ? U : [];
 
 /** A function type which is assignable to any other function type (and any function is assignable to). */
 type Callback = (...args: any) => any;
+// Note: we use `...args: any` so `...args: infer U` is assignable to it (as opposed to `...args: Array<any>`)
 
 declare const enum LocationType {
 	MobileWebsite = 0,

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -89,7 +89,7 @@ type InstanceProperties<I extends Instance> = OriginalInstanceType<I> extends in
 	: never;
 
 /** Given an Instance `T`, returns a unioned type of all non-readonly property names. */
-type WritableInstanceProperties<I extends Instance> = WritableProperties<OriginalInstanceType<I>>;
+type WritableInstanceProperties<I extends Instance> = Extract<WritableProperties<OriginalInstanceType<I>>, keyof I>;
 
 /** Given an Instance `T`, returns an object which can hold the writable properties of T. Good to use with `Object.assign`.
  * @example
@@ -100,7 +100,7 @@ type WritableInstanceProperties<I extends Instance> = WritableProperties<Origina
  *
  * Object.assign(new Instance("Part"), props);
  */
-type PartialInstance<T extends Instance> = Partial<Pick<T, Extract<WritableInstanceProperties<T>, keyof T>>>;
+type PartialInstance<T extends Instance> = Partial<Pick<T, WritableInstanceProperties<T>>>;
 
 // temporary backwards compatibility:
 


### PR DESCRIPTION
Here is what the `OriginalInstanceType` gives us:
```ts
type A = OriginalInstanceType<Part | Folder>; // Part | Folder
type B = OriginalInstanceType<StrictInstances["Part"] & { X: StringValue }>; // Part
type C = OriginalInstanceType<Configuration & { Setting: BoolValue; Setting2: StringValue }> // Configuration
type D = OriginalInstanceType<Part & { X: StringValue } | Folder & { Y: StringValue }>; // Part | Folder
```

By using this in types like `PartialInstance`, we can now properly isolate only the real properties of a given instance!

This code used to contain no errors:
```ts
function foo(part: PartialInstance<Part & { X: StringValue }>) {
	const p = Object.assign(new Instance("Part"), part);
	part.X; // error! Good!
	const x = new Instance("StringValue")
	x.Name = "X";
	x.Value = "";
	x.Parent = p;
	return p;
}

foo({ X: new Instance("StringValue") }); // error! Good!
```

Changes:
- Made `Instace.Changed`, `Workspace.BreakJoints` and `Workspace.MakeJoints` readonly properties.
- Added `WritableProperties` and `PartialProperties`
- Made `InstanceProperties` and `WritableInstanceProperties` use `OriginalInstanceType`
  - `InstanceProperties` used to omit `GetPropertyChangedSignal` by way of blacklist, now it just does so in its `Callback -> never` check. I believe this used to be necessary due to a limitation in TypeScript which no longer exists.
  - `WritableInstanceProperties` no longer needs to blacklist *any* properties. Now, its definition is just `WritableProperties<OriginalInstanceType<I>>`
