### PR TITLE
Make iterating over objects where `keyof T` is never have an `any` fallback type

### DIFF
--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -95,6 +95,8 @@ interface ObjectConstructor {
 		? Array<K>
 		: T extends ArrayLike<any>
 		? Array<number>
+		: keyof T extends never
+		? Array<any>
 		: Array<keyof T>;
 
 	/**
@@ -112,6 +114,8 @@ interface ObjectConstructor {
 		? Array<NonNullable<V>>
 		: T extends ArrayLike<infer W>
 		? Array<NonNullable<W>>
+		: keyof T extends never
+		? Array<any>
 		: Array<NonNullable<T[keyof T]>>;
 
 	/**
@@ -129,7 +133,9 @@ interface ObjectConstructor {
 		? Array<[K, NonNullable<V>]>
 		: T extends ArrayLike<infer W>
 		? Array<[number, NonNullable<W>]>
-		: Array<NonNullable<{ [K in keyof T]: [K, NonNullable<T[K]>] }[keyof T]>>;
+		: keyof T extends never
+		? Array<[any, any]>
+		: Array<[keyof T, NonNullable<T[keyof T]>]>;
 
 	/** Creates an object from a set of entries */
 	fromEntries<P extends readonly [string | number | symbol, unknown]>(

--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -96,7 +96,7 @@ interface ObjectConstructor {
 		: T extends ArrayLike<any>
 		? Array<number>
 		: keyof T extends never
-		? Array<any>
+		? Array<unknown>
 		: Array<keyof T>;
 
 	/**
@@ -115,7 +115,7 @@ interface ObjectConstructor {
 		: T extends ArrayLike<infer W>
 		? Array<NonNullable<W>>
 		: keyof T extends never
-		? Array<any>
+		? Array<unknown>
 		: Array<NonNullable<T[keyof T]>>;
 
 	/**
@@ -134,7 +134,7 @@ interface ObjectConstructor {
 		: T extends ArrayLike<infer W>
 		? Array<[number, NonNullable<W>]>
 		: keyof T extends never
-		? Array<[any, any]>
+		? Array<[unknown, unknown]>
 		: Array<[keyof T, NonNullable<T[keyof T]>]>;
 
 	/** Creates an object from a set of entries */


### PR DESCRIPTION
With the new changes:

```ts
function takesObject(obj: object) {
	for (const [i, v] of Object.entries(obj)) {
		i; // any
		v; // any
	}
}
```
This also helps for types which are too difficult for TS to evaluate as a generic!
```ts
export function cloneInstance<T extends Instance>(object: T, parent: Instance, properties: PartialInstance<T>): T {
	const myNewInstance = object.Clone();

	for (const [i, v] of Object.entries(properties)) {
		myNewInstance[i as WritableInstanceProperties<T>] = v; // i and v are `any`
	}

	myNewInstance.Parent = parent;
	return myNewInstance;
}
```

Also simplifies `Array<NonNullable<{ [K in keyof T]: [K, NonNullable<T[K]>] }[keyof T]>>` to `Array<[keyof T, NonNullable<T[keyof T]>]>`. Technically, this definition is less accurate, but it makes it super easy for TS to merge it in the case of union types.

```ts
for (const b of Object.entries({ x: 1, y: 2, z: "x" })) {
	// b used to be ["x", number] | ["y", number] | ["z", string]
	// b is now ["x" | "y" | "z", string | number]
}
```

However, I think most people are pretty much always going to destructure `b` in-line anyway. If someone *needs* that type, they can safely use an `as` assertion:
`as { [K in keyof T]: [K, T[K]] }[keyof T]`