### PR TITLE
Allow Map<string, string> as HttpHeaders

### DIFF
--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -192,11 +192,12 @@ interface GetGroupsAsyncResult {
 	IsInClan: boolean;
 }
 
+type HttpHeaders = Record<string, string> | Map<string, string>;
 interface RequestAsyncRequest {
 	Url: string;
 	Method?: "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "PATCH";
 	Body?: string;
-	Headers?: Record<string, string> | Map<string, string>;
+	Headers?: HttpHeaders;
 }
 
 interface RequestAsyncResponse {

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -192,22 +192,18 @@ interface GetGroupsAsyncResult {
 	IsInClan: boolean;
 }
 
-interface HttpHeaders {
-	[index: string]: string;
-}
-
 interface RequestAsyncRequest {
 	Url: string;
 	Method?: "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "PATCH";
 	Body?: string;
-	Headers?: HttpHeaders;
+	Headers?: Record<string, string> | Map<string, string>;
 }
 
 interface RequestAsyncResponse {
 	Success: boolean;
 	StatusCode: number;
 	StatusMessage: string;
-	Headers: HttpHeaders;
+	Headers: Record<string, string>;
 	Body: string;
 }
 


### PR DESCRIPTION
Type only used once => removed. Response still only uses Record<string, string>