### PR TITLE
Don't use function overloading in macro_math

### DIFF
--- a/include/macro_math.d.ts
+++ b/include/macro_math.d.ts
@@ -4,67 +4,67 @@
 
 declare interface CFrame {
 	/** macro for the `+` operator */
-	add(this: CFrame, v3: Vector3): CFrame;
+	add(this: CFrame, op: Vector3): CFrame;
 	/** macro for the `-` operator */
-	sub(this: CFrame, v3: Vector3): CFrame;
+	sub(this: CFrame, op: Vector3): CFrame;
 	/** macro for the `*` operator */
-	mul(this: CFrame, cf: CFrame | Vector3): CFrame;
+	mul<T extends CFrame | Vector3>(this: CFrame, op: T): T;
 }
 
 declare interface UDim {
 	/** macro for the `+` operator */
-	add(this: UDim, udim: UDim): UDim;
+	add(this: UDim, op: UDim): UDim;
 	/** macro for the `-` operator */
-	sub(this: UDim, udim: UDim): UDim;
+	sub(this: UDim, op: UDim): UDim;
 }
 
 declare interface UDim2 {
 	/** macro for the `+` operator */
-	add(this: UDim2, udim2: UDim2): UDim2;
+	add(this: UDim2, op: UDim2): UDim2;
 	/** macro for the `-` operator */
-	sub(this: UDim2, udim2: UDim2): UDim2;
+	sub(this: UDim2, op: UDim2): UDim2;
 }
 
 declare interface Vector2 {
 	/** macro for the `+` operator */
-	add(this: Vector2, v2: Vector2): Vector2;
+	add(this: Vector2, op: Vector2): Vector2;
 	/** macro for the `-` operator */
-	sub(this: Vector2, v2: Vector2): Vector2;
+	sub(this: Vector2, op: Vector2): Vector2;
 	/** macro for the `*` operator */
-	mul(this: Vector2, v2: Vector2 | number): Vector2;
+	mul(this: Vector2, op: Vector2 | number): Vector2;
 	/** macro for the `/` operator */
-	div(this: Vector2, v2: Vector2 | number): Vector2;
+	div(this: Vector2, op: Vector2 | number): Vector2;
 }
 
 declare interface Vector2int16 {
 	/** macro for the `+` operator */
-	add(this: Vector2int16, v2: Vector2int16): Vector2int16;
+	add(this: Vector2int16, op: Vector2int16): Vector2int16;
 	/** macro for the `-` operator */
-	sub(this: Vector2int16, v2: Vector2int16): Vector2int16;
+	sub(this: Vector2int16, op: Vector2int16): Vector2int16;
 	/** macro for the `*` operator */
-	mul(this: Vector2int16, v2: Vector2int16): Vector2int16;
+	mul(this: Vector2int16, op: Vector2int16): Vector2int16;
 	/** macro for the `/` operator */
-	div(this: Vector2int16, v2: Vector2int16): Vector2int16;
+	div(this: Vector2int16, op: Vector2int16): Vector2int16;
 }
 
 declare interface Vector3 {
 	/** macro for the `+` operator */
-	add(this: Vector3, v3: Vector3): Vector3;
+	add(this: Vector3, op: Vector3): Vector3;
 	/** macro for the `-` operator */
-	sub(this: Vector3, v3: Vector3): Vector3;
+	sub(this: Vector3, op: Vector3): Vector3;
 	/** macro for the `*` operator */
-	mul(this: Vector3, v3: Vector3 | number): Vector3;
+	mul(this: Vector3, op: Vector3 | number): Vector3;
 	/** macro for the `/` operator */
-	div(this: Vector3, v3: Vector3 | number): Vector3;
+	div(this: Vector3, op: Vector3 | number): Vector3;
 }
 
 declare interface Vector3int16 {
 	/** macro for the `+` operator */
-	add(this: Vector3int16, v3: Vector3int16): Vector3int16;
+	add(this: Vector3int16, op: Vector3int16): Vector3int16;
 	/** macro for the `-` operator */
-	sub(this: Vector3int16, v3: Vector3int16): Vector3int16;
+	sub(this: Vector3int16, op: Vector3int16): Vector3int16;
 	/** macro for the `*` operator */
-	mul(this: Vector3int16, v3: Vector3int16): Vector3int16;
+	mul(this: Vector3int16, op: Vector3int16): Vector3int16;
 	/** macro for the `/` operator */
-	div(this: Vector3int16, v3: Vector3int16): Vector3int16;
+	div(this: Vector3int16, op: Vector3int16): Vector3int16;
 }

--- a/include/macro_math.d.ts
+++ b/include/macro_math.d.ts
@@ -3,78 +3,68 @@
 // MACRO MATH API
 
 declare interface CFrame {
-	/** macro for CFrame * CFrame */
-	mul(this: CFrame, cf: CFrame): CFrame;
-	/** macro for CFrame * Vector3 */
-	mul(this: CFrame, v3: Vector3): Vector3;
-	/** macro for CFrame + Vector3 */
+	/** macro for the `+` operator */
 	add(this: CFrame, v3: Vector3): CFrame;
-	/** macro for CFrame - Vector3 */
+	/** macro for the `-` operator */
 	sub(this: CFrame, v3: Vector3): CFrame;
+	/** macro for the `*` operator */
+	mul(this: CFrame, cf: CFrame | Vector3): CFrame;
 }
 
 declare interface UDim {
-	/** macro for UDim + UDim */
+	/** macro for the `+` operator */
 	add(this: UDim, udim: UDim): UDim;
-	/** macro for UDim - UDim */
+	/** macro for the `-` operator */
 	sub(this: UDim, udim: UDim): UDim;
 }
 
 declare interface UDim2 {
-	/** macro for UDim2 + UDim2 */
+	/** macro for the `+` operator */
 	add(this: UDim2, udim2: UDim2): UDim2;
-	/** macro for UDim2 - UDim2 */
+	/** macro for the `-` operator */
 	sub(this: UDim2, udim2: UDim2): UDim2;
 }
 
 declare interface Vector2 {
-	/** macro for Vector2 + Vector2 */
+	/** macro for the `+` operator */
 	add(this: Vector2, v2: Vector2): Vector2;
-	/** macro for Vector2 - Vector2 */
+	/** macro for the `-` operator */
 	sub(this: Vector2, v2: Vector2): Vector2;
-	/** macro for Vector2 * Vector2 */
-	mul(this: Vector2, v2: Vector2): Vector2;
-	/** macro for Vector2 * number */
-	mul(this: Vector2, n: number): Vector2;
-	/** macro for Vector2 / Vector2 */
-	div(this: Vector2, v2: Vector2): Vector2;
-	/** macro for Vector2 / number */
-	div(this: Vector2, n: number): Vector2;
+	/** macro for the `*` operator */
+	mul(this: Vector2, v2: Vector2 | number): Vector2;
+	/** macro for the `/` operator */
+	div(this: Vector2, v2: Vector2 | number): Vector2;
 }
 
 declare interface Vector2int16 {
-	/** macro for Vector2int16 + Vector2int16 */
+	/** macro for the `+` operator */
 	add(this: Vector2int16, v2: Vector2int16): Vector2int16;
-	/** macro for Vector2int16 - Vector2int16 */
+	/** macro for the `-` operator */
 	sub(this: Vector2int16, v2: Vector2int16): Vector2int16;
-	/** macro for Vector2int16 * Vector2int16 */
+	/** macro for the `*` operator */
 	mul(this: Vector2int16, v2: Vector2int16): Vector2int16;
-	/** macro for Vector2int16 / Vector2int16 */
+	/** macro for the `/` operator */
 	div(this: Vector2int16, v2: Vector2int16): Vector2int16;
 }
 
 declare interface Vector3 {
-	/** macro for Vector3 + Vector3 */
+	/** macro for the `+` operator */
 	add(this: Vector3, v3: Vector3): Vector3;
-	/** macro for Vector3 - Vector3 */
+	/** macro for the `-` operator */
 	sub(this: Vector3, v3: Vector3): Vector3;
-	/** macro for Vector3 * Vector3 */
-	mul(this: Vector3, v3: Vector3): Vector3;
-	/** macro for Vector3 * number */
-	mul(this: Vector3, n: number): Vector3;
-	/** macro for Vector3 / Vector3 */
-	div(this: Vector3, v3: Vector3): Vector3;
-	/** macro for Vector3 / number */
-	div(this: Vector3, n: number): Vector3;
+	/** macro for the `*` operator */
+	mul(this: Vector3, v3: Vector3 | number): Vector3;
+	/** macro for the `/` operator */
+	div(this: Vector3, v3: Vector3 | number): Vector3;
 }
 
 declare interface Vector3int16 {
-	/** macro for Vector2int16 + Vector2int16 */
+	/** macro for the `+` operator */
 	add(this: Vector3int16, v3: Vector3int16): Vector3int16;
-	/** macro for Vector2int16 - Vector2int16 */
+	/** macro for the `-` operator */
 	sub(this: Vector3int16, v3: Vector3int16): Vector3int16;
-	/** macro for Vector2int16 * Vector2int16 */
+	/** macro for the `*` operator */
 	mul(this: Vector3int16, v3: Vector3int16): Vector3int16;
-	/** macro for Vector2int16 / Vector2int16 */
+	/** macro for the `/` operator */
 	div(this: Vector3int16, v3: Vector3int16): Vector3int16;
 }


### PR DESCRIPTION
Removes function overloading from macro_math. In my opinion, function overloading is the wrong choice in most cases because I don't think we intend to disallow calls where the non-thisType parameter type is the union of the both types present in the overload:

```ts
function allowed_1(a: Vector2, b: Vector2) {
	const c = a.mul(b);
}

function allowed_2(a: Vector2, b: number) {
	const c = a.mul(b);
}

function disallowed(a: Vector2, b: Vector2 | number) {
	const c = a.mul(b); // error?
}
```