### PR TITLE
Remove plugin-only tag from ScriptContext

### DIFF
--- a/src/class/ClassGenerator.ts
+++ b/src/class/ClassGenerator.ts
@@ -145,7 +145,6 @@ const PLUGIN_ONLY_CLASSES = new Set([
 	"RenderingTest",
 	"RenderSettings",
 	"RobloxPluginGuiService",
-	"ScriptContext",
 	"ScriptDebugger",
 	"Selection",
 	"StatsItem",


### PR DESCRIPTION
Mostly used for ScriptContext.Error event