### PR TITLE
Make pairs check if object extends from Required<T>

### DIFF
--- a/include/lua.d.ts
+++ b/include/lua.d.ts
@@ -680,7 +680,7 @@ declare function pairs<K, V>(
 ): IterableFunction<LuaTuple<[Exclude<K, undefined>, Exclude<V, undefined>]>>;
 declare function pairs<T extends object>(
 	object: T,
-): object extends T
+): object extends Required<T>
 	? IterableFunction<LuaTuple<[unknown, defined]>>
 	: IterableFunction<LuaTuple<[keyof T, Exclude<T[keyof T], undefined>]>>;
 


### PR DESCRIPTION
The current implementation has `pairs` return `IterableFunction<LuaTuple<[unknown, defined]>>` for objects whose members are all optional.