### PR TITLE
Update lua.d.ts

### DIFF
--- a/include/lua.d.ts
+++ b/include/lua.d.ts
@@ -15,7 +15,7 @@ declare const _VERSION: string;
 declare function collectgarbage(option: "count"): number;
 
 /** Terminates the last protected function called and outputs message as an error message. If the function containing the error is not called in a protected function (pcall), then the script which called the function will terminate. The error function itself never returns and acts like a script error. The level argument specifies how to get the error position. With level 1 (the default), the error position is where the error function was called. Level 2 points the error to where the function that called error was called; and so on. Passing a level 0 avoids the addition of error position information to the message. */
-declare function error(message?: string, level?: number): never;
+declare function error(message?: unknown, level?: number): never;
 
 /** Returns the current environment in use by the function. If provided with a function, the environment of the function will be returned as an array. If provided with an integer, getfenv will provide the environment of the function at the provided stack level: Level 1 is the function calling getfenv. If stack is 0, getfenv returns the global environment of the current script. When using getfenv to get the current environment of a script, it will return the same table every time within the specific thread. */
 declare function getfenv(stack: number): { script: LuaSourceContainer };


### PR DESCRIPTION
Since Luau, for a few months, error() has supported throwing anything, not just strings. The types should reflect that.