### PR TITLE
Change DeveloperConsoleVisible->DevConsoleVisible

### DIFF
--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -2010,7 +2010,7 @@ interface SettableCores {
 	ChatBarDisabled: boolean;
 	SendNotification: SendNotificationConfig;
 	TopbarEnabled: boolean;
-	DeveloperConsoleVisible: boolean;
+	DevConsoleVisible: boolean;
 	PromptSendFriendRequest: Player;
 	PromptUnfriend: Player;
 	PromptBlockPlayer: Player;


### PR DESCRIPTION
Roblox has silently changed this value or it was misdocumented. Attempting to SetCore DeveloperConsoleVisible will error out because the core scripts haven't registered it, but using DevConsoleVisible in its place will not error. After digging some further, this is what `/console` in the lua chat system uses, so this should be fairly well supported. 