### PR TITLE
Add `Function` to `Callback` type conversion

### DIFF
--- a/src/class/ClassGenerator.ts
+++ b/src/class/ClassGenerator.ts
@@ -376,6 +376,7 @@ const VALUE_TYPE_MAP = new Map<string, string | null>([
 	["double", "number"],
 	["EventInstance", "RBXScriptSignal"],
 	["float", "number"],
+	["Function", "Callback"],
 	["int", "number"],
 	["int64", "number"],
 	["Map", "object"],


### PR DESCRIPTION
The `Function` type is only for TS requirements, the `Callback` type is preferred for roblox-ts usage.