### PR TITLE
Revert "Bump node-fetch from 2.6.6 to 3.2.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"eslint-plugin-simple-import-sort": "^7.0.0",
 				"fs-extra": "^10.0.0",
 				"libxmljs2": "^0.29.0",
-				"node-fetch": "=3.2.3",
+				"node-fetch": "=2.6.6",
 				"prettier": "^2.1.2",
 				"ts-morph": "^14.0.0",
 				"typescript": "^4.0.3"
@@ -1075,15 +1075,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/data-uri-to-buffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -1670,29 +1661,6 @@
 				"reusify": "^1.0.4"
 			}
 		},
-		"node_modules/fetch-blob": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-			"integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"dependencies": {
-				"node-domexception": "^1.0.0",
-				"web-streams-polyfill": "^3.0.3"
-			},
-			"engines": {
-				"node": "^12.20 || >= 14.13"
-			}
-		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1811,18 +1779,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/formdata-polyfill": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-			"dev": true,
-			"dependencies": {
-				"fetch-blob": "^3.1.2"
-			},
-			"engines": {
-				"node": ">=12.20.0"
 			}
 		},
 		"node_modules/fs-extra": {
@@ -2527,41 +2483,16 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"node_modules/node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "github",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"engines": {
-				"node": ">=10.5.0"
-			}
-		},
 		"node_modules/node-fetch": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.3.tgz",
-			"integrity": "sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==",
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+			"integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
 			"dev": true,
 			"dependencies": {
-				"data-uri-to-buffer": "^4.0.0",
-				"fetch-blob": "^3.1.4",
-				"formdata-polyfill": "^4.0.10"
+				"whatwg-url": "^5.0.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/node-fetch"
+				"node": "4.x || >=6.0.0"
 			}
 		},
 		"node_modules/nopt": {
@@ -3400,15 +3331,6 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
 			"integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
 			"dev": true
-		},
-		"node_modules/web-streams-polyfill": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-			"integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
-			}
 		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
@@ -4282,12 +4204,6 @@
 			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
 			"dev": true
 		},
-		"data-uri-to-buffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-			"dev": true
-		},
 		"debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -4733,16 +4649,6 @@
 				"reusify": "^1.0.4"
 			}
 		},
-		"fetch-blob": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-			"integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-			"dev": true,
-			"requires": {
-				"node-domexception": "^1.0.0",
-				"web-streams-polyfill": "^3.0.3"
-			}
-		},
 		"file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4823,15 +4729,6 @@
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"mime-types": "^2.1.12"
-			}
-		},
-		"formdata-polyfill": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-			"dev": true,
-			"requires": {
-				"fetch-blob": "^3.1.2"
 			}
 		},
 		"fs-extra": {
@@ -5393,21 +5290,13 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-			"dev": true
-		},
 		"node-fetch": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.3.tgz",
-			"integrity": "sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==",
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+			"integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
 			"dev": true,
 			"requires": {
-				"data-uri-to-buffer": "^4.0.0",
-				"fetch-blob": "^3.1.4",
-				"formdata-polyfill": "^4.0.10"
+				"whatwg-url": "^5.0.0"
 			}
 		},
 		"nopt": {
@@ -6044,12 +5933,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
 			"integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
-			"dev": true
-		},
-		"web-streams-polyfill": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-			"integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
 			"dev": true
 		},
 		"webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"eslint-plugin-simple-import-sort": "^7.0.0",
 		"fs-extra": "^10.0.0",
 		"libxmljs2": "^0.29.0",
-		"node-fetch": "=3.2.3",
+		"node-fetch": "=2.6.6",
 		"prettier": "^2.1.2",
 		"ts-morph": "^14.0.0",
 		"typescript": "^4.0.3"


### PR DESCRIPTION
Reverts roblox-ts/types#559
New version is broken for importing, which breaks build CI