### PR TITLE
Add missing parameters to TeleportService.TeleportInitFailed

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -764,7 +764,7 @@ interface TeleportService extends Instance {
 	readonly LocalPlayerArrivedFromTeleport: RBXScriptSignal<(loadingGui: ScreenGui, dataTable?: unknown) => void>;
 
 	readonly TeleportInitFailed: RBXScriptSignal<
-		(player: Player, teleportResult: Enum.TeleportResult, errorMessage: string) => void
+		(player: Player, teleportResult: Enum.TeleportResult, errorMessage: string, placeId: number, teleportOptions: TeleportOptions) => void
 	>;
 	/** @server */
 	GetPlayerPlaceInstanceAsync(this: TeleportService, userId: number): LuaTuple<[boolean, string, number, string]>;

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -764,7 +764,13 @@ interface TeleportService extends Instance {
 	readonly LocalPlayerArrivedFromTeleport: RBXScriptSignal<(loadingGui: ScreenGui, dataTable?: unknown) => void>;
 
 	readonly TeleportInitFailed: RBXScriptSignal<
-		(player: Player, teleportResult: Enum.TeleportResult, errorMessage: string, placeId: number, teleportOptions: TeleportOptions) => void
+		(
+			player: Player,
+			teleportResult: Enum.TeleportResult,
+			errorMessage: string,
+			placeId: number,
+			teleportOptions: TeleportOptions,
+		) => void
 	>;
 	/** @server */
 	GetPlayerPlaceInstanceAsync(this: TeleportService, userId: number): LuaTuple<[boolean, string, number, string]>;


### PR DESCRIPTION
Per [the DevForum announcement](https://devforum.roblox.com/t/1652500) and [documentation](https://developer.roblox.com/en-us/api-reference/event/TeleportService/TeleportInitFailed).