### PR TITLE
Fix HapticService.SetMotor vibration parameter

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -346,7 +346,7 @@ interface HapticService extends Instance {
 		this: HapticService,
 		inputType: CastsToEnum<Enum.UserInputType>,
 		motor: CastsToEnum<Enum.VibrationMotor>,
-		vibration: number
+		vibration: number,
 	): void;
 }
 

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -342,7 +342,12 @@ interface GuiService extends Instance {
 }
 
 interface HapticService extends Instance {
-	SetMotor(this: HapticService, inputType: CastsToEnum<Enum.UserInputType>, motor: CastsToEnum<Enum.VibrationMotor>, vibration: number): void;
+	SetMotor(
+		this: HapticService,
+		inputType: CastsToEnum<Enum.UserInputType>,
+		motor: CastsToEnum<Enum.VibrationMotor>,
+		vibration: number
+	): void;
 }
 
 interface HttpService extends Instance {

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -341,6 +341,10 @@ interface GuiService extends Instance {
 	Select(this: GuiService, selectionParent: Instance): void;
 }
 
+interface HapticService extends Instance {
+	SetMotor(this: HapticService, inputType: CastsToEnum<Enum.UserInputType>, motor: CastsToEnum<Enum.VibrationMotor>, vibration: number): void;
+}
+
 interface HttpService extends Instance {
 	/** @server */
 	GetAsync(this: HttpService, url: string, nocache?: boolean, headers?: HttpHeaders): string;


### PR DESCRIPTION
This seems to not actually be typechecked by HapticService itself.
The examples in the documentation all use a single number, and specify it should be between 0 and 1.
The API dump and method signature on the developer hub show it as `vibrationValues: tuple`.