### PR TITLE
Add debug.setmemorycategory and resetmemorycategory

### DIFF
--- a/include/lua.d.ts
+++ b/include/lua.d.ts
@@ -306,7 +306,7 @@ declare namespace debug {
 		: T extends `${infer A}${infer _}`
 		? LuaTuple<TS.InfoFlags<[A]>>
 		: LuaTuple<[unknown, unknown, unknown, unknown, unknown]>;
-	
+
 	/**
 	 * Assigns a custom tag name to the current thread's memory category in the Developer Console. Useful for analyzing memory usage of multiple threads in the same script which would otherwise be grouped together under the same tag/name.
 	 */

--- a/include/lua.d.ts
+++ b/include/lua.d.ts
@@ -306,6 +306,15 @@ declare namespace debug {
 		: T extends `${infer A}${infer _}`
 		? LuaTuple<TS.InfoFlags<[A]>>
 		: LuaTuple<[unknown, unknown, unknown, unknown, unknown]>;
+	
+	/**
+	 * Assigns a custom tag name to the current thread's memory category in the Developer Console. Useful for analyzing memory usage of multiple threads in the same script which would otherwise be grouped together under the same tag/name.
+	 */
+	function setmemorycategory(tag: string): void;
+	/**
+	 * Resets the tag assigned by `debug.setmemorycategory` to the automatically assigned value (typically, the script name).
+	 */
+	function resetmemorycategory(): void;
 }
 
 interface String {


### PR DESCRIPTION
Adds the `debug.setmemorycategory(tag)` and
`debug.resetmemorycategory()` functions from the Roblox API.

References:
* https://create.roblox.com/docs/reference/engine/libraries/debug#setmemorycategory
* https://devforum.roblox.com/t/developer-console-update-for-luau-memory-use-tracking/1224560
* https://github.com/Kampfkarren/selene/commit/d9a0b3343b32c9a282350df8ce23d25f238f4a62