### PR TITLE
Fix MarketplaceService.GetProductInfo second parameter not being optional

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -485,11 +485,7 @@ interface MarketplaceService extends Instance {
 		assetId: number,
 		infoType: CastsToEnum<Enum.InfoType.GamePass>,
 	): AssetProductInfo;
-	GetProductInfo(
-		this: MarketplaceService,
-		assetId: number,
-		infoType?: CastsToEnum<Enum.InfoType>,
-	): ProductInfo;
+	GetProductInfo(this: MarketplaceService, assetId: number, infoType?: CastsToEnum<Enum.InfoType>): ProductInfo;
 	PromptProductPurchase(
 		this: MarketplaceService,
 		player: Player,

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -488,8 +488,8 @@ interface MarketplaceService extends Instance {
 	GetProductInfo(
 		this: MarketplaceService,
 		assetId: number,
-		infoType: CastsToEnum<Enum.InfoType>,
-	): AssetProductInfo | DeveloperProductInfo;
+		infoType?: CastsToEnum<Enum.InfoType>,
+	): ProductInfo;
 	PromptProductPurchase(
 		this: MarketplaceService,
 		player: Player,


### PR DESCRIPTION
Should work correctly with regard to the overloads?