### PR TITLE
Remove duplicate shouldGenerateClass check

### DIFF
--- a/src/class/ClassGenerator.ts
+++ b/src/class/ClassGenerator.ts
@@ -1275,7 +1275,7 @@ export class ClassGenerator extends Generator {
 		this.write(`// GENERATED ROBLOX INSTANCE CLASSES`);
 		this.write(``);
 		for (const rbxClass of rbxClasses) {
-			if (this.shouldGenerateClass(rbxClass)) this.generateClass(rbxClass, sourceFile);
+			this.generateClass(rbxClass, sourceFile);
 		}
 	}
 


### PR DESCRIPTION
https://github.com/roblox-ts/types/pull/668/files#diff-5fef075c2474e41fd36cae18db2b02a425db72727e9ec03a2e8bd6fe93ed77d5R1346
Already filtered before the function is called