### PR TITLE
EnableGamepadCursor guiObject parameter is optional

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -238,6 +238,10 @@ interface Dragger extends Instance {
 interface FriendPages
 	extends Pages<{ AvatarFinal: boolean; AvatarUri: string; Id: number; Username: string; IsOnline: boolean }> {}
 
+interface GamepadService extends Instance {
+	EnableGamepadCursor(this: GamepadService, guiObject?: GuiObject): void;
+}
+
 interface GamePassService extends Instance {
 	/** This item is deprecated. Do not use it for new work. */
 	PlayerHasPass(this: GamePassService, player: Player, gamePassId: number): boolean;

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -239,7 +239,7 @@ interface FriendPages
 	extends Pages<{ AvatarFinal: boolean; AvatarUri: string; Id: number; Username: string; IsOnline: boolean }> {}
 
 interface GamepadService extends Instance {
-	EnableGamepadCursor(this: GamepadService, guiObject?: GuiObject): void;
+	EnableGamepadCursor(this: GamepadService, guiObject: GuiObject | undefined): void;
 }
 
 interface GamePassService extends Instance {


### PR DESCRIPTION
Per the https://devforum.roblox.com/t/1798094 announcement.

There is one issue though. If `nil` or a GuiObject isn't specifically passed, then the function errors - the parameter cannot be void. I hope the types being written as `| undefined` address this(?)