### PR TITLE
Fail process when errors in types are found

### DIFF
--- a/src/class/ClassGenerator.ts
+++ b/src/class/ClassGenerator.ts
@@ -1121,8 +1121,9 @@ export class ClassGenerator extends Generator {
 			const superClassName = this.generateClassName(rbxClass.Superclass);
 			extendsStr = `extends ${superClassName} `;
 			if (tsImplInterface) {
-				const originalExtends = tsImplInterface.getExtends()[0]?.getText();
-				if (!originalExtends?.startsWith(superClassName)) {
+				// getExpression separates a possible <TypeGenerics> part
+				const originalExtends = tsImplInterface.getExtends()[0].getExpression().getText();
+				if (originalExtends !== superClassName) {
 					console.warn(
 						`\`${rbxClass.Name}\` had its parent class changed to \`${superClassName}\`, was \`${originalExtends}\``,
 					);

--- a/src/class/ClassGenerator.ts
+++ b/src/class/ClassGenerator.ts
@@ -19,6 +19,7 @@ import {
 	MemberTag,
 	SecurityType,
 } from "../api";
+import { fatal } from "../util";
 import { Generator } from "./Generator";
 import { ReflectionMetadata } from "./ReflectionMetadata";
 
@@ -1124,9 +1125,7 @@ export class ClassGenerator extends Generator {
 				// getExpression separates a possible <TypeGenerics> part
 				const originalExtends = tsImplInterface.getExtends()[0].getExpression().getText();
 				if (originalExtends !== superClassName) {
-					console.warn(
-						`\`${rbxClass.Name}\` had its parent class changed to \`${superClassName}\`, was \`${originalExtends}\``,
-					);
+					fatal(rbxClass.Name, "had its parent class changed from", originalExtends, "to", superClassName);
 				}
 			}
 		}
@@ -1181,7 +1180,7 @@ export class ClassGenerator extends Generator {
 						const obj = rbxClass.Members.find(member => member.Name === name);
 
 						if (obj === undefined && !EXPECTED_EXTRA_MEMBERS.get(className)?.includes(name)) {
-							console.warn("could not find", className + "." + name);
+							fatal("Unknown member", className + "." + name, "was found in customDefinitions.d.ts");
 						}
 						const [signature, documentation] = this.getSignature(custom);
 						if (documentation.trim()) this.write(documentation);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,4 @@
+export function fatal(...messages: Array<string>) {
+	console.error(messages.join(" "));
+	process.exitCode = 1;
+}


### PR DESCRIPTION
This is probably better than producing types where properties silently go missing (in the case of parent classes changing).