### PR TITLE
Fix EnumGenerator

### DIFF
--- a/src/class/EnumGenerator.ts
+++ b/src/class/EnumGenerator.ts
@@ -67,10 +67,12 @@ export class EnumGenerator extends Generator {
 				}
 				this.write(``);
 			}
-			this.write(`export function GetEnumItems(this: Enum): Array<${enumTypeName}>`);
+			this.write(`export function GetEnumItems(this: globalThis.Enum): Array<${enumTypeName}>;`);
 			this.popIndent();
 			this.write(`}`);
-			this.write(`export type ${enumTypeName} = ${enumTypeName}.${enumItemNames.join(` | ${enumTypeName}.`)};`);
+			const enumUnion = enumItemNames.map(enumItemName => `${enumTypeName}.${enumItemName}`).join(` | `);
+			this.write(`export type ${enumTypeName} = ${enumUnion};`);
+			this.write(``);
 		}
 		this.popIndent();
 		this.write(`}`);

--- a/src/class/EnumGenerator.ts
+++ b/src/class/EnumGenerator.ts
@@ -70,9 +70,7 @@ export class EnumGenerator extends Generator {
 			this.write(`export function GetEnumItems(this: globalThis.Enum): Array<globalThis.Enum.${enumTypeName}>;`);
 			this.popIndent();
 			this.write(`}`);
-			const enumUnion = enumItemNames.map(enumItemName => `${enumTypeName}.${enumItemName}`).join(` | `);
-			this.write(`export type ${enumTypeName} = ${enumUnion};`);
-			this.write(``);
+			this.write(`export type ${enumTypeName} = ${enumTypeName}.${enumItemNames.join(` | ${enumTypeName}.`)};`);
 		}
 		this.popIndent();
 		this.write(`}`);

--- a/src/class/EnumGenerator.ts
+++ b/src/class/EnumGenerator.ts
@@ -45,11 +45,11 @@ export class EnumGenerator extends Generator {
 				LegacyNames: enumItemLegacyNames,
 			} of enumTypeItems) {
 				enumItemNames.push(enumItemName);
-				this.write(`export interface ${enumItemName} extends EnumItem {`);
+				this.write(`export interface ${enumItemName} extends globalThis.EnumItem {`);
 				this.pushIndent();
 				this.write(`Name: "${enumItemName}";`);
 				this.write(`Value: ${enumItemValue};`);
-				this.write(`EnumType: typeof ${enumTypeName};`);
+				this.write(`EnumType: typeof globalThis.Enum.${enumTypeName};`);
 				this.popIndent();
 				this.write(`}`);
 				this.write(``);
@@ -67,7 +67,7 @@ export class EnumGenerator extends Generator {
 				}
 				this.write(``);
 			}
-			this.write(`export function GetEnumItems(this: globalThis.Enum): Array<${enumTypeName}>;`);
+			this.write(`export function GetEnumItems(this: globalThis.Enum): Array<globalThis.Enum.${enumTypeName}>;`);
 			this.popIndent();
 			this.write(`}`);
 			const enumUnion = enumItemNames.map(enumItemName => `${enumTypeName}.${enumItemName}`).join(` | `);


### PR DESCRIPTION
- Prevent collisions when an enum has a value named:
  - `Enum`
  - `EnumItem`
  - the same as the enum itself i.e. `Enum.Foo.Foo`
- Fix missing semicolon
- More reasonable map + join for enum union value
- Improved whitespace

To test this, I added this to the top of `EnumGenerator.generate()`:
```TS
		rbxEnums.push({
			Name: "Foo",
			Items: [
				{
					Name: "Foo",
					Value: 1,
				},
				{
					Name: "Bar",
					Value: 2,
				},
				{
					Name: "Enum",
					Value: 3,
				},
				{
					Name: "EnumItem",
					Value: 4,
				},
			],
		});
```

which resulted in this:

```TS
	export namespace Foo {
		export interface Foo extends globalThis.EnumItem {
			Name: "Foo";
			Value: 1;
			EnumType: typeof globalThis.Enum.Foo;
		}

		export const Foo: Foo;

		export interface Bar extends globalThis.EnumItem {
			Name: "Bar";
			Value: 2;
			EnumType: typeof globalThis.Enum.Foo;
		}

		export const Bar: Bar;

		export interface Enum extends globalThis.EnumItem {
			Name: "Enum";
			Value: 3;
			EnumType: typeof globalThis.Enum.Foo;
		}

		export const Enum: Enum;

		export interface EnumItem extends globalThis.EnumItem {
			Name: "EnumItem";
			Value: 4;
			EnumType: typeof globalThis.Enum.Foo;
		}

		export const EnumItem: EnumItem;

		export function GetEnumItems(this: globalThis.Enum): Array<globalThis.Enum.Foo>;
	}
	export type Foo = Foo.Foo | Foo.Bar | Foo.Enum | Foo.EnumItem;
```

[Playground link of before](https://roblox-ts.com/playground/#code/KYDwDg9gTgLgBAbwL4G4BQaAmwDGAbAQymDgHM8IAjAvRNASADsCBbYAZzAJxIFFGArizr16oSLDjM2nbiQBiECCNHjo8AJaMYwKADM5cRctA7GmdnH5CAkjuEIGo+gDlWwAFxwARMe-pnegA1GgFPOABGAOdrFgAVAE8wcJgk4Ag9IyVo+iQMZzVJHAhGdnhjL2N0JzFwdTgtHX1DACEiOFNgc0tYu2AHGtd3L282qH9BkLwwrwAmHPpYxOSvVOSMrIgcvJrC+GLS+DGvMeqCuslG3QMeK0FhTu6723sVUTc2EdiJwKmZuAAzAslmlVmkNlUajtzhJ9iUys8WF5YmdVBdNNproZeq9HhZEX0BoEPuFvDj+j9nH9wgAWYH3ZYpcGZSHOaFo2FwA4I8lIgn2VG1Tl6ASMHAwDQlOAAcWAMF57AAFDAABYadjI+4ASi8AEEoFACAkADzGAB80TyHPqawUSjgAF5NgA6YxwAA+LrGHpdsR9xmdvICeTyQA)

[Playground link of after](https://roblox-ts.com/playground/#code/KYDwDg9gTgLgBAbwL4G4BQaAmwDGAbAQymDgHM8IAjAvRNASADsCBbYAZzAJxIFFGArizr16oSLDjM2nbiQBiECCNHjo8AJaMYwKADM5cRctA7GmdmQrU8AFQAWG9gDp+QgJI7hCBqPoA5VmAALjgAImMw9D96ADUaARC4AEZovzcWWwBPMCSYHOAIPSsqGgcnV0EWZ2M0+iQMPzVJHAhGdnhjUNrG1XB1OC0dfUMAISI4U2BzS3JSu0cXDM9gb19RQLZQsPGoKPW4hKSAJjr6DOzc0PzcopKbcqWqmqU6hvXm+Fb2+F3Q3fQH36kiGugMPDgGUmIDMFnuZUWlQ8XhUGyC2wy+xi8TwiVCAGYzhcCtcCnc5g9ERkXhA3r0xMCvm0OpCqqEMoCmozBtowYZliipjN4QsKgLVqiAujwuKWFi-Di8XAACxEqqXPJk4oUhFi549PzvLkSJk-VnI1bsqorFicvomuB6ASMHAwDRtOAAcWAMFl7AAFDBFqEdaKnkIAJShACCUCgBCyAB5Q48kdVjAA+NINe0DG4KJRwAC8RiUNLgAB9SxBnLtK9W0-XjGmbdEGg0gA)