### PR TITLE
Add `Font.fromName` and `Font.fromId` constructor functions

### DIFF
--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -1527,8 +1527,8 @@ interface Font {
 interface FontConstructor {
 	new (family: string, weight?: Enum.FontWeight, style?: Enum.FontStyle): Font;
 	fromEnum: (value: Enum.Font) => Font;
-	fromName: (name: string, weight: Enum.FontWeight, style: Enum.FontStyle) => Font;
-	fromId: (id: number, weight: Enum.FontWeight, style: Enum.FontStyle) => Font;
+	fromName: (name: string, weight?: Enum.FontWeight, style?: Enum.FontStyle) => Font;
+	fromId: (id: number, weight?: Enum.FontWeight, style?: Enum.FontStyle) => Font;
 }
 declare const Font: FontConstructor;
 

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -1527,6 +1527,8 @@ interface Font {
 interface FontConstructor {
 	new (family: string, weight?: Enum.FontWeight, style?: Enum.FontStyle): Font;
 	fromEnum: (value: Enum.Font) => Font;
+	fromName: (name: string, weight: Enum.FontWeight, style: Enum.FontStyle) => Font;
+	fromId: (id: number, weight: Enum.FontWeight, style: Enum.FontStyle) => Font;
 }
 declare const Font: FontConstructor;
 


### PR DESCRIPTION
Add the missing [`fromName`](https://create.roblox.com/docs/reference/engine/datatypes/Font#fromName) and [`fromId`](https://create.roblox.com/docs/reference/engine/datatypes/Font#fromId) Font constructor functions.