### PR TITLE
Fix empty enums bug

### DIFF
--- a/src/class/EnumGenerator.ts
+++ b/src/class/EnumGenerator.ts
@@ -70,10 +70,11 @@ export class EnumGenerator extends Generator {
 			this.write(`export function GetEnumItems(this: globalThis.Enum): Array<globalThis.Enum.${enumTypeName}>;`);
 			this.popIndent();
 			this.write(`}`);
-			if (enumItemNames.length > 0) {
-				const enumUnion = enumItemNames.map(enumItemName => `${enumTypeName}.${enumItemName}`).join(` | `);
-				this.write(`export type ${enumTypeName} = ${enumUnion};`);
-			}
+			const enumUnion =
+				enumItemNames.length > 0
+					? enumItemNames.map(enumItemName => `${enumTypeName}.${enumItemName}`).join(` | `)
+					: "never";
+			this.write(`export type ${enumTypeName} = ${enumUnion};`);
 			this.write(``);
 		}
 		this.popIndent();

--- a/src/class/EnumGenerator.ts
+++ b/src/class/EnumGenerator.ts
@@ -70,8 +70,10 @@ export class EnumGenerator extends Generator {
 			this.write(`export function GetEnumItems(this: globalThis.Enum): Array<globalThis.Enum.${enumTypeName}>;`);
 			this.popIndent();
 			this.write(`}`);
-			const enumUnion = enumItemNames.map(enumItemName => `${enumTypeName}.${enumItemName}`).join(` | `);
-			this.write(`export type ${enumTypeName} = ${enumUnion};`);
+			if (enumItemNames.length > 0) {
+				const enumUnion = enumItemNames.map(enumItemName => `${enumTypeName}.${enumItemName}`).join(` | `);
+				this.write(`export type ${enumTypeName} = ${enumUnion};`);
+			}
 			this.write(``);
 		}
 		this.popIndent();


### PR DESCRIPTION
If an enum contains no members, this results in a generation of:
```TS
export type MyEnum = ;
```
which is invalid syntax. The typecheck step then fails which stops the build/publish.