### PR TITLE
Use conditional type for pairs() return

### DIFF
--- a/include/lua.d.ts
+++ b/include/lua.d.ts
@@ -223,6 +223,16 @@ declare namespace TS {
 			? Callback
 			: never;
 	}>;
+
+	type PairsHelper<T> = T extends ReadonlyArray<infer V>
+		? [number, Exclude<V, undefined>]
+		: T extends ReadonlySet<infer K>
+		? [K, true]
+		: T extends ReadonlyMap<infer K, infer V>
+		? [K, Exclude<V, undefined>]
+		: keyof T extends never
+		? [unknown, defined]
+		: [keyof T, Exclude<T[keyof T], undefined>];
 }
 
 declare namespace debug {
@@ -791,16 +801,6 @@ declare function next<K, V>(object: ReadonlyMap<K, V>, index?: K): LuaTuple<[K, 
 declare function next<T extends object>(object: T, index?: keyof T): LuaTuple<[keyof T, T[keyof T]]>;
 declare function next(object: object, index?: unknown): LuaTuple<[unknown, unknown]>;
 
-type PairsHelper<T> = T extends ReadonlyArray<infer V>
-	? [number, Exclude<V, undefined>]
-	: T extends ReadonlySet<infer K>
-	? [K, true]
-	: T extends ReadonlyMap<infer K, infer V>
-	? [K, Exclude<V, undefined>]
-	: keyof T extends never
-	? [unknown, defined]
-	: [keyof T, Exclude<T[keyof T], undefined>];
-
-declare function pairs<T extends object>(object: T): IterableFunction<LuaTuple<PairsHelper<T>>>;
+declare function pairs<T extends object>(object: T): IterableFunction<LuaTuple<TS.PairsHelper<T>>>;
 
 declare function ipairs<T>(object: ReadonlyArray<T>): IterableFunction<LuaTuple<[number, Exclude<T, undefined>]>>;

--- a/include/lua.d.ts
+++ b/include/lua.d.ts
@@ -791,15 +791,16 @@ declare function next<K, V>(object: ReadonlyMap<K, V>, index?: K): LuaTuple<[K, 
 declare function next<T extends object>(object: T, index?: keyof T): LuaTuple<[keyof T, T[keyof T]]>;
 declare function next(object: object, index?: unknown): LuaTuple<[unknown, unknown]>;
 
-declare function pairs<T>(object: ReadonlyArray<T>): IterableFunction<LuaTuple<[number, Exclude<T, undefined>]>>;
-declare function pairs<T>(object: ReadonlySet<T>): IterableFunction<LuaTuple<[T, true]>>;
-declare function pairs<K, V>(
-	object: ReadonlyMap<K, V>,
-): IterableFunction<LuaTuple<[Exclude<K, undefined>, Exclude<V, undefined>]>>;
-declare function pairs<T extends object>(
-	object: T,
-): keyof T extends never
-	? IterableFunction<LuaTuple<[unknown, defined]>>
-	: IterableFunction<LuaTuple<[keyof T, Exclude<T[keyof T], undefined>]>>;
+type PairsHelper<T> = T extends ReadonlyArray<infer V>
+	? [number, Exclude<V, undefined>]
+	: T extends ReadonlySet<infer K>
+	? [K, true]
+	: T extends ReadonlyMap<infer K, infer V>
+	? [K, Exclude<V, undefined>]
+	: keyof T extends never
+	? [unknown, defined]
+	: [keyof T, Exclude<T[keyof T], undefined>];
+
+declare function pairs<T extends object>(object: T): IterableFunction<LuaTuple<PairsHelper<T>>>;
 
 declare function ipairs<T>(object: ReadonlyArray<T>): IterableFunction<LuaTuple<[number, Exclude<T, undefined>]>>;


### PR DESCRIPTION
Fixes issues when providing a union, eg `pairs(a)` where `a: Map<Instance, unknown> | Set<Instance>`.
[Current behaviour with overloads](https://roblox-ts.com/playground/#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwFsBPAByixgGcAeAFQD4AKAKAEgcAjAK3AwC54AJRBRgeCEQCCMGFCJ16AGmYBKAQEkMIWRwggAYmky5U1ADLIotZCT3UA2qmQEO2xfACiAD0jJQddzRQRCxUEGB6AF16egBuZlBIWAQUdGw8QlJyKgVGTh5MAWFRcSIAZRAMBTV4TW0oXQMjdNMLKxs7e1p3DBhkEGi4hPBoOCRmk0yyChoAaXcANSY2fN4ikTFUCQBZKBJqefgl5Rq6nT1DNJNzS2tbEAdvX39DoJAQsIj3J4g-B4XAqhgqFwlEYvFEqMUhMMsRpjlaPAQF4tEDKPBVphluxuGt4N1VAIANYgIg4RD4pEokBo+BhABu2jYAH5alpzk0rngbu17g40ETUDgAO6odzAz6DNgadkNC4w1q3DoPewkskU7qeHy-fy0VWk8n4yKAiWgwbxZhw7KURhhYXwXb7JwuNzwSi9UIAcyYKhU8StM1tIHtFSq6lQ7qg6BAPr9zGGSTGYDw7vgUAEjuo4cj0fcAG8AL70eAAH3goazEYwUbAMfiiBwMHgjGTVfg9g47jAkQxFIDVEYUF98DzbA48VYYHiBeYQA)
[New behaviour with conditional type](https://roblox-ts.com/playground/#code/C4TwDgpgBACghgSwE4GcASEA2kkB4AqAfFALxT5QQAewEAdgCYpQBKEcDA9nZiAIJIkcELgR0AZhCRQAaoQBQASAD8UANp0ArgFsARlIA0UAKJUAxpk0MIuGUc2MI4sRAaEAukoBc5SjXpMrOxcPCAAyhDAohJSUADSCirqcUbASJoQnoo+FNS0jMxsHNy8ALJwYNGS0ilQYtWyiapqtaYWVjZ2UA7WznSuHt5QANYQIJzivnkBzP0AblJKzQ7DdJwA7nRGvS4MWT5qo+OT+EZtltYEh2MT5O72jn0D7gDc8vLWFnBI0OIOZsAENwoNpwIhUARCAAKTi6ABWEABOQAlD4AJK0IS6TAQABi-0B3FwABlNHB8JowDjcPBkOgsDhIYRCG95KCwOCUFD+usoOVKlo9IYoCg0mIAObQ5HIt7sznciC8iJRNF0UVwOhmCBSmXvT6Yb7QMzcUVQOA+fm4VXqzUQIwAbwAvsQAD5QZVWtXADValnycScaRQ41e9S6IxmdxQW5yulQuDSqD2pS6N6KMxvR3yIA)