### PR TITLE
Fixed type with `HapticService.SetMotor`

### DIFF
--- a/include/generated/None.d.ts
+++ b/include/generated/None.d.ts
@@ -14337,7 +14337,7 @@ interface HapticService extends Instance {
 		this: HapticService,
 		inputType: CastsToEnum<Enum.UserInputType>,
 		motor: CastsToEnum<Enum.VibrationMotor>,
-		vibration: number,
+		...vibrationValues: Array<number>,
 	): void;
 }
 


### PR DESCRIPTION
Docs say this takes a tuple (which might actually be incorrect internally, but I can't be sure), so to be as accurate as possible I've changed thate.