### PR TITLE
Use Full-API-Dump.json for typing gen

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ import { Timer } from "./class/Timer";
 
 const SECURITY_LEVELS = ["None", "PluginSecurity"] as const;
 
-const BASE_URL = "https://raw.githubusercontent.com/MaximumADHD/Roblox-Client-Tracker/roblox/";
-const API_DUMP_URL = BASE_URL + "Mini-API-Dump.json";
+const BASE_URL = "https://github.com/MaximumADHD/Roblox-Client-Tracker/raw/roblox/";
+const API_DUMP_URL = BASE_URL + "Full-API-Dump.json";
 const REFLECTION_METADATA_URL = BASE_URL + "ReflectionMetadata.xml";
 
 void (async () => {


### PR DESCRIPTION
[Info already on Max's repo](https://github.com/MaximumADHD/Roblox-Client-Tracker/pull/27), this is what the typing gen should be using as opposed to the "normal" API dump, which omits many classes and APIs. It's unreliable, and requires redundant 'patches' on class APIs.