### PR TITLE
Add SharedTable datatype

### DIFF
--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -1854,6 +1854,18 @@ type RotationCurveKeyConstructor = new (
 ) => RotationCurveKey;
 declare const RotationCurveKey: RotationCurveKeyConstructor;
 
+// SharedTable
+interface SharedTable {
+	/**
+	 * **DO NOT USE!**
+	 *
+	 * This field exists to force TypeScript to recognize this as a nominal type
+	 * @hidden
+	 * @deprecated
+	 */
+	readonly _nominal_SharedTable: unique symbol;
+}
+
 // TextChatMessage
 interface TextChatMessage {
 	/**


### PR DESCRIPTION
Used by undocumented [SharedTableRegistry](https://create.roblox.com/docs/reference/engine/classes/SharedTableRegistry)
Fixes recent build failures