### PR TITLE
Fix `ContentProvider.PreloadAsync` being unable to take `string` types

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -149,7 +149,7 @@ interface CompressorSoundEffect extends SoundEffect {
 interface ContentProvider extends Instance {
 	PreloadAsync(
 		this: ContentProvider,
-		contentIdList: Array<Instance>,
+		contentIdList: Array<Instance | string>,
 		callback?: (contentId: string, status: Enum.AssetFetchStatus) => void,
 	): void;
 }

--- a/include/generated/None.d.ts
+++ b/include/generated/None.d.ts
@@ -7912,7 +7912,7 @@ interface ContentProvider extends Instance {
 	 */
 	PreloadAsync(
 		this: ContentProvider,
-		contentIdList: Array<Instance>,
+		contentIdList: Array<Instance | string>,
 		callback?: (contentId: string, status: Enum.AssetFetchStatus) => void,
 	): void;
 	readonly AssetFetchFailed: RBXScriptSignal<(assetId: string) => void>;


### PR DESCRIPTION
err just read the title