### PR TITLE
Fix `PhysicsService:GetRegisteredCollisionGroups`

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -657,7 +657,8 @@ interface PathfindingService extends Instance {
 }
 
 interface PhysicsService extends Instance {
-	GetCollisionGroups(this: PhysicsService): Array<CollisionGroupInfo>;
+	GetCollisionGroups(this: PhysicsService): Array<CollisionGroupInfo & { id: number }>;
+	GetRegisteredCollisionGroups(this: PhysicsService): Array<CollisionGroupInfo>;
 }
 
 interface Player extends Instance {

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -657,7 +657,6 @@ interface PathfindingService extends Instance {
 }
 
 interface PhysicsService extends Instance {
-	GetCollisionGroups(this: PhysicsService): Array<CollisionGroupInfo & { id: number }>;
 	GetRegisteredCollisionGroups(this: PhysicsService): Array<CollisionGroupInfo>;
 }
 

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -361,7 +361,6 @@ interface AgentParameters {
 }
 
 interface CollisionGroupInfo {
-	id: number;
 	mask: number;
 	name: string;
 }


### PR DESCRIPTION
Current type returns `unknown`.

The old `CollisionGroupInfo` type had an info field, which I have added explicitly to the deprecated `GetCollisionGroups`, in favor of using the type for `GetRegisteredCollisionGroups`.