### PR TITLE
Add DataStoreGetOptions to GetAsync params

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -243,7 +243,11 @@ interface DataModel extends ServiceProvider<Services> {
 }
 
 interface DataStore extends GlobalDataStore {
-	GetAsync<T>(this: DataStore, key: string): LuaTuple<[T | undefined, DataStoreKeyInfo]>;
+	GetAsync<T>(
+		this: DataStore, 
+		key: string,
+		options?: DataStoreGetOptions,
+	): LuaTuple<[T | undefined, DataStoreKeyInfo]>;
 	GetVersionAsync(
 		this: DataStore,
 		key: string,
@@ -279,7 +283,7 @@ interface DataStorePages extends Pages<{ key: string; value: unknown }> {}
 /** @server */
 interface DataStoreService extends Instance {
 	GetDataStore(this: DataStoreService, name: string, scope?: string, options?: DataStoreOptions): DataStore;
-	GetGlobalDataStore(this: DataStoreService): GlobalDataStore;
+	GetGlobalDataStore(this: DataStoreService): DataStore;
 	GetOrderedDataStore(this: DataStoreService, name: string, scope?: string): OrderedDataStore;
 }
 

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -244,7 +244,7 @@ interface DataModel extends ServiceProvider<Services> {
 
 interface DataStore extends GlobalDataStore {
 	GetAsync<T>(
-		this: DataStore, 
+		this: DataStore,
 		key: string,
 		options?: DataStoreGetOptions,
 	): LuaTuple<[T | undefined, DataStoreKeyInfo]>;

--- a/include/generated/None.d.ts
+++ b/include/generated/None.d.ts
@@ -11454,7 +11454,11 @@ interface DataStore extends GlobalDataStore {
 	 * @deprecated
 	 */
 	readonly _nominal_DataStore: unique symbol;
-	GetAsync<T>(this: DataStore, key: string): LuaTuple<[T | undefined, DataStoreKeyInfo]>;
+	GetAsync<T>(
+		this: DataStore, 
+		key: string,
+		options?: DataStoreGetOptions,
+	): LuaTuple<[T | undefined, DataStoreKeyInfo]>;
 	IncrementAsync(
 		this: DataStore,
 		key: string,

--- a/include/generated/None.d.ts
+++ b/include/generated/None.d.ts
@@ -9887,7 +9887,7 @@ interface DataStoreService extends Instance {
 	/**
 	 * This function returns the default [GlobalDataStore](https://developer.roblox.com/en-us/api-reference/class/GlobalDataStore). If you want to access a specific **named** data store instead, you should use the [GetDataStore()](https://developer.roblox.com/en-us/api-reference/function/DataStoreService/GetDataStore) function.
 	 */
-	GetGlobalDataStore(this: DataStoreService): GlobalDataStore;
+	GetGlobalDataStore(this: DataStoreService): DataStore;
 	/**
 	 * This method returns an [OrderedDataStore](https://developer.roblox.com/en-us/api-reference/class/OrderedDataStore), similar to the way [GetDataStore()](https://developer.roblox.com/en-us/api-reference/function/DataStoreService/GetDataStore) does with [GlobalDataStores](https://developer.roblox.com/en-us/api-reference/class/GlobalDataStore). Subsequent calls to this method with the same name/scope will return the same object.
 	 */

--- a/include/generated/None.d.ts
+++ b/include/generated/None.d.ts
@@ -11549,26 +11549,10 @@ interface OrderedDataStore extends GlobalDataStore {
 	 * @deprecated
 	 */
 	readonly _nominal_OrderedDataStore: unique symbol;
-	GetAsync(
-		this: OrderedDataStore, 
-		key: string,
-		options?: DataStoreGetOptions,
-	): number | undefined;
-	IncrementAsync(
-		this: OrderedDataStore, 
-		key: string, 
-		delta?: number,
-		userIds?: Array<number>,
-		options?: DataStoreIncrementOptions,
-	): number;
+	GetAsync(this: OrderedDataStore, key: string): number | undefined;
+	IncrementAsync(this: OrderedDataStore, key: string, delta?: number): number;
 	RemoveAsync(this: OrderedDataStore, key: string): number | undefined;
-	SetAsync(
-		this: OrderedDataStore, 
-		key: string, 
-		value?: number,
-		userIds?: Array<number>,
-		options?: DataStoreSetOptions,
-	): void;
+	SetAsync(this: OrderedDataStore, key: string, value?: unknown): void;
 	UpdateAsync(
 		this: OrderedDataStore,
 		key: string,

--- a/include/generated/None.d.ts
+++ b/include/generated/None.d.ts
@@ -9887,7 +9887,7 @@ interface DataStoreService extends Instance {
 	/**
 	 * This function returns the default [GlobalDataStore](https://developer.roblox.com/en-us/api-reference/class/GlobalDataStore). If you want to access a specific **named** data store instead, you should use the [GetDataStore()](https://developer.roblox.com/en-us/api-reference/function/DataStoreService/GetDataStore) function.
 	 */
-	GetGlobalDataStore(this: DataStoreService): DataStore;
+	GetGlobalDataStore(this: DataStoreService): GlobalDataStore;
 	/**
 	 * This method returns an [OrderedDataStore](https://developer.roblox.com/en-us/api-reference/class/OrderedDataStore), similar to the way [GetDataStore()](https://developer.roblox.com/en-us/api-reference/function/DataStoreService/GetDataStore) does with [GlobalDataStores](https://developer.roblox.com/en-us/api-reference/class/GlobalDataStore). Subsequent calls to this method with the same name/scope will return the same object.
 	 */
@@ -11549,10 +11549,26 @@ interface OrderedDataStore extends GlobalDataStore {
 	 * @deprecated
 	 */
 	readonly _nominal_OrderedDataStore: unique symbol;
-	GetAsync(this: OrderedDataStore, key: string): number | undefined;
-	IncrementAsync(this: OrderedDataStore, key: string, delta?: number): number;
+	GetAsync(
+		this: OrderedDataStore, 
+		key: string,
+		options?: DataStoreGetOptions,
+	): number | undefined;
+	IncrementAsync(
+		this: OrderedDataStore, 
+		key: string, 
+		delta?: number,
+		userIds?: Array<number>,
+		options?: DataStoreIncrementOptions,
+	): number;
 	RemoveAsync(this: OrderedDataStore, key: string): number | undefined;
-	SetAsync(this: OrderedDataStore, key: string, value?: unknown): void;
+	SetAsync(
+		this: OrderedDataStore, 
+		key: string, 
+		value?: number,
+		userIds?: Array<number>,
+		options?: DataStoreSetOptions,
+	): void;
 	UpdateAsync(
 		this: OrderedDataStore,
 		key: string,

--- a/include/generated/None.d.ts
+++ b/include/generated/None.d.ts
@@ -11454,11 +11454,7 @@ interface DataStore extends GlobalDataStore {
 	 * @deprecated
 	 */
 	readonly _nominal_DataStore: unique symbol;
-	GetAsync<T>(
-		this: DataStore, 
-		key: string,
-		options?: DataStoreGetOptions,
-	): LuaTuple<[T | undefined, DataStoreKeyInfo]>;
+	GetAsync<T>(this: DataStore, key: string): LuaTuple<[T | undefined, DataStoreKeyInfo]>;
 	IncrementAsync(
 		this: DataStore,
 		key: string,


### PR DESCRIPTION
Roblox has recently added DataStoreGetOptions to the `GetAsync` method to GlobalDataStore. 