### PR TITLE
Close fs stream after generating each file

### DIFF
--- a/src/class/ClassGenerator.ts
+++ b/src/class/ClassGenerator.ts
@@ -1399,5 +1399,7 @@ export class ClassGenerator extends Generator {
 		this.generateHeader();
 		this.generateInstancesTables(rbxClasses.filter(rbxClass => !this.definedClassNames.has(rbxClass.Name)));
 		this.generateClasses(rbxClasses, sourceFile);
+
+		await this.finish();
 	}
 }

--- a/src/class/EnumGenerator.ts
+++ b/src/class/EnumGenerator.ts
@@ -84,5 +84,7 @@ export class EnumGenerator extends Generator {
 		this.write(`}`);
 		this.write(``);
 		this.write(`declare type CastsToEnum<T extends EnumItem> = T | T["Name" | "Value"];`);
+
+		await this.finish();
 	}
 }

--- a/src/class/Generator.ts
+++ b/src/class/Generator.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 import { ReflectionMetadata } from "./ReflectionMetadata";
 
-export class Generator {
+export abstract class Generator {
 	protected stream: fs.WriteStream;
 	protected indent = "";
 
@@ -25,5 +25,11 @@ export class Generator {
 
 	public write(line: string) {
 		this.stream.write((line.length > 0 ? this.indent + line : "") + "\n");
+	}
+
+	protected finish() {
+		return new Promise(resolve => {
+			this.stream.close(resolve);
+		});
 	}
 }


### PR DESCRIPTION
Currently, `PluginSecurity.d.ts` sometimes does not get written to the file system if diagnostics are found, because the `process.exit(1)` seems to cancel the usual opportunity for the stream to auto-close. This PR fixes it by explicitly calling the stream's close method after each generation step is done.