### PR TITLE
Fix: MemoryStoreSortedMap SetAsync sortKey parameter

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -603,7 +603,7 @@ interface MemoryStoreSortedMap extends Instance {
 		transformFunction: (value: unknown) => T,
 		expiration: number,
 	): T;
-	SetAsync<T>(
+	SetAsync(
 		this: MemoryStoreSortedMap,
 		key: string,
 		value: unknown,

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -603,6 +603,13 @@ interface MemoryStoreSortedMap extends Instance {
 		transformFunction: (value: unknown) => T,
 		expiration: number,
 	): T;
+	SetAsync<T>(
+		this: MemoryStoreSortedMap,
+		key: string,
+		value: unknown,
+		expiration: number,
+		sortKey?: string | number,
+	): boolean;
 }
 
 /** @server */


### PR DESCRIPTION
The current type for MemoryStoreSortedMap:SetAsync() is:
```ts
SetAsync(this: MemoryStoreSortedMap, key: string, value: unknown, expiration: number, sortKey: unknown): boolean;
```

As per Roblox documentation, sortKey is optional and can only be a string or a number.
![image](https://github.com/roblox-ts/types/assets/34319439/747aca4f-971b-4e6a-a9cd-1673fadf2c96)
