### PR TITLE
Added TweenService:GetValue()

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -1026,6 +1026,12 @@ interface TweenService extends Instance {
 		tweenInfo: TweenInfo,
 		propertyTable: Partial<ExtractMembers<T, Tweenable>>,
 	): Tween;
+	GetValue(
+		this: TweenService,
+		alpha: number,
+		easingStyle: CastsToEnum<Enum.EasingStyle>,
+		easingDirection: CastsToEnum<Enum.EasingDirection>,
+	): number;
 }
 
 interface UIPageLayout extends UIGridStyleLayout {


### PR DESCRIPTION
I noticed that this method was missing and I added it using the appropriate types.

https://create.roblox.com/docs/reference/engine/classes/TweenService#GetValue
![resim](https://github.com/roblox-ts/types/assets/121735715/cf15284c-e578-4112-ab55-2a9ad02db4dc)
