### PR TITLE
Remove AbstractInstances interface

### DIFF
--- a/src/class/ClassGenerator.ts
+++ b/src/class/ClassGenerator.ts
@@ -289,61 +289,6 @@ function safeName(name: string) {
 	return containsBadChar(name) ? `["${name.replace(/"/g, '\\"')}"]` : name;
 }
 
-const ABSTRACT_CLASSES = new Set<string>([
-	"BackpackItem",
-	"BasePart",
-	"BasePlayerGui",
-	"BaseScript",
-	"BevelMesh",
-	"BodyMover",
-	"CharacterAppearance",
-	"Clothing",
-	"Constraint",
-	"Controller",
-	"DataModelMesh",
-	"DynamicRotate",
-	"FaceInstance",
-	"Feature",
-	"FormFactorPart",
-	"GenericSettings",
-	"GuiBase",
-	"GuiBase2d",
-	"GuiBase3d",
-	"GuiButton",
-	"GuiLabel",
-	"GuiObject",
-	"HandleAdornment",
-	"HandlesBase",
-	"Instance",
-	"JointInstance",
-	"LayerCollector",
-	"Light",
-	"LuaSourceContainer",
-	"ManualSurfaceJointInstance",
-	"NetworkPeer",
-	"NetworkReplicator",
-	"Pages",
-	"PartAdornment",
-	"PluginGui",
-	"PostEffect",
-	"PVAdornment",
-	"PVInstance",
-	"SelectionLasso",
-	"ServiceProvider",
-	"SlidingBallConstraint",
-	"SoundEffect",
-	"StatsItem",
-	"TriangleMeshPart",
-	"TweenBase",
-	"UIBase",
-	"UIComponent",
-	"UIConstraint",
-	"UIGridStyleLayout",
-	"UILayout",
-	"ValueBase",
-	"WorldRoot",
-]);
-
 const PROP_TYPE_MAP = new Map<string, string>();
 
 function safePropType(valueType: string | undefined | null) {
@@ -1307,8 +1252,8 @@ export class ClassGenerator extends Generator {
 	}
 
 	private generateInstancesTables(rbxClasses: Array<ApiClass>) {
-		const [Services, CreatableInstances, AbstractInstances, Instances] = multifilter(rbxClasses, 4, rbxClass =>
-			hasTag(rbxClass, "Service") ? 0 : isCreatable(rbxClass) ? 1 : ABSTRACT_CLASSES.has(rbxClass.Name) ? 2 : 3,
+		const [Services, CreatableInstances, Instances] = multifilter(rbxClasses, 3, rbxClass =>
+			hasTag(rbxClass, "Service") ? 0 : isCreatable(rbxClass) ? 1 : 2,
 		);
 
 		// for sorting
@@ -1318,15 +1263,8 @@ export class ClassGenerator extends Generator {
 		if (0 < CreatableInstances.length) {
 			this.generateInstanceInterface("CreatableInstances", CreatableInstances.sort(byName));
 		}
-		if (0 < CreatableInstances.length) {
-			this.generateInstanceInterface("AbstractInstances", AbstractInstances.sort(byName));
-		}
 		if (0 < Instances.length) {
-			this.generateInstanceInterface(
-				"Instances",
-				Instances.sort(byName),
-				"Services, CreatableInstances, AbstractInstances",
-			);
+			this.generateInstanceInterface("Instances", Instances.sort(byName), "Services, CreatableInstances");
 		}
 	}
 


### PR DESCRIPTION
Doesn't serve any known use-cases*, and was hand-maintained and outdated.

*It used to be used in the `classIs` signature, but was removed from that in roblox-ts/compiler-types#4.