### PR TITLE
Add custom definitions for `EditableMesh`

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -314,6 +314,17 @@ interface Dragger extends Instance {
 	MouseDown(this: Dragger, mousePart: BasePart, pointOnMousePart: Vector3, parts: Array<BasePart>): void;
 }
 
+interface EditableMesh extends DataModelMesh {
+	FindClosestPointOnSurface(this: EditableMesh, point: Vector3): LuaTuple<[number, Vector3, Vector3]>;
+	FindVerticesWithinSphere(this: EditableMesh, center: Vector3, radius: number): Array<number>;
+	GetAdjacentTriangles(this: EditableMesh, triangleId: number): Array<number>;
+	GetAdjacentVertices(this: EditableMesh, vertexId: number): Array<number>;
+	GetTriangleVertices(this: EditableMesh, triangleId: number): LuaTuple<[number, number, number]>;
+	GetTriangles(this: EditableMesh): Array<number>;
+	GetVertices(this: EditableMesh): Array<number>;
+	RaycastLocal(this: EditableMesh, origin: Vector3, direction: Vector3): LuaTuple<[number, Vector3, Vector3]>;
+}
+
 interface EmotesPages extends InventoryPages {}
 
 interface FriendPages


### PR DESCRIPTION
![image](https://github.com/roblox-ts/types/assets/10765258/862f7283-e71b-4de7-b770-5935847cc856)

closes #1191 

Pending discussion item: Do we want to replace `number` with `VertexId` or `FaceId` (or equivalent) where applicable? ([Original discussion](https://discord.com/channels/476080952636997633/494540040991539200/1213239076334084116)).