### PR TITLE
Fixed GetRangeAsync not having correct optional parameters

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -629,7 +629,13 @@ interface MemoryStoreSortedMap extends Instance {
 		expiration: number,
 		sortKey?: string | number,
 	): boolean;
-	GetRangeAsync(this: MemoryStoreSortedMap, direction: CastsToEnum<Enum.SortDirection>, count: number, exclusiveLowerBound?: unknown, exclusiveUpperBound?: unknown): unknown;
+	GetRangeAsync(
+    	this: MemoryStoreSortedMap,
+    	direction: CastsToEnum<Enum.SortDirection>,
+    	count: number,
+    	exclusiveLowerBound?: unknown,
+    	exclusiveUpperBound?: unknown
+	): unknown;
 }
 
 /** @server */

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -629,6 +629,7 @@ interface MemoryStoreSortedMap extends Instance {
 		expiration: number,
 		sortKey?: string | number,
 	): boolean;
+	GetRangeAsync(this: MemoryStoreSortedMap, direction: CastsToEnum<Enum.SortDirection>, count: number, exclusiveLowerBound?: unknown, exclusiveUpperBound?: unknown): unknown;
 }
 
 /** @server */

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -633,13 +633,10 @@ interface MemoryStoreSortedMap extends Instance {
 		this: MemoryStoreSortedMap,
 		direction: CastsToEnum<Enum.SortDirection>,
 		count: number,
-		exclusiveLowerBound?: { key?: string, sortKey?: string | number },
-		exclusiveUpperBound?: { key?: string, sortKey?: string | number },
-	): Array<{ key: string, value: unknown, sortKey?: string | number }>;
-	GetAsync(
-		this: MemoryStoreSortedMap,
-		key: string
-	): LuaTuple<[key?: string, sortKey?: string | number]>;
+		exclusiveLowerBound?: { key?: string; sortKey?: string | number },
+		exclusiveUpperBound?: { key?: string; sortKey?: string | number },
+	): Array<{ key: string; value: unknown; sortKey?: string | number }>;
+	GetAsync(this: MemoryStoreSortedMap, key: string): LuaTuple<[key?: string, sortKey?: string | number]>;
 }
 
 /** @server */

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -630,11 +630,11 @@ interface MemoryStoreSortedMap extends Instance {
 		sortKey?: string | number,
 	): boolean;
 	GetRangeAsync(
-    	this: MemoryStoreSortedMap,
-    	direction: CastsToEnum<Enum.SortDirection>,
-    	count: number,
-    	exclusiveLowerBound?: unknown,
-    	exclusiveUpperBound?: unknown
+		this: MemoryStoreSortedMap,
+		direction: CastsToEnum<Enum.SortDirection>,
+		count: number,
+		exclusiveLowerBound?: unknown,
+		exclusiveUpperBound?: unknown,
 	): unknown;
 }
 

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -633,9 +633,13 @@ interface MemoryStoreSortedMap extends Instance {
 		this: MemoryStoreSortedMap,
 		direction: CastsToEnum<Enum.SortDirection>,
 		count: number,
-		exclusiveLowerBound?: unknown,
-		exclusiveUpperBound?: unknown,
-	): unknown;
+		exclusiveLowerBound?: { key?: string, sortKey?: string | number },
+		exclusiveUpperBound?: { key?: string, sortKey?: string | number },
+	): Array<{ key: string, value: unknown, sortKey?: string | number }>;
+	GetAsync(
+		this: MemoryStoreSortedMap,
+		key: string
+	): LuaTuple<[key?: string, sortKey?: string | number]>;
 }
 
 /** @server */


### PR DESCRIPTION
Hello,
according to the [docs](https://create.roblox.com/docs/reference/engine/classes/MemoryStoreSortedMap#GetRangeAsync), the `GetRangeAsync` should have `exclusiveLowerBound` and `exclusiveUpperBound` as optional parametrs, while currently that's not the case.
![image](https://github.com/roblox-ts/types/assets/40070133/8bcc7625-76ed-46b2-a726-aeb0bfd805c3)


![image](https://github.com/roblox-ts/types/assets/40070133/d061ee54-1faf-4b04-a2b6-b6c86f4ca513)
