### PR TITLE
Correct types for MemoryStoreSortedMap#GetAsync

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -670,7 +670,7 @@ interface MemoryStoreSortedMap extends Instance {
 		exclusiveLowerBound?: { key?: string; sortKey?: string | number },
 		exclusiveUpperBound?: { key?: string; sortKey?: string | number },
 	): Array<{ key: string; value: unknown; sortKey?: string | number }>;
-	GetAsync(this: MemoryStoreSortedMap, key: string): LuaTuple<[key?: string, sortKey?: string | number]>;
+	GetAsync(this: MemoryStoreSortedMap, key: string): LuaTuple<[value?: unknown, sortKey?: string | number]>;
 }
 
 /** @server */


### PR DESCRIPTION
https://create.roblox.com/docs/reference/engine/classes/MemoryStoreSortedMap#GetAsync

`Key value, or nil -- if there's no item with the specified key.`