### PR TITLE
Add `AgentCanClimb` to `AgentParameters`

### DIFF
--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -355,6 +355,8 @@ interface AgentParameters {
 	AgentHeight?: number;
 	/** Sets whether off-mesh links for jumping are allowed. */
 	AgentCanJump?: boolean;
+	/** Determines whether climbing `TrussParts` during pathfinding is allowed. */
+	AgentCanClimb?: boolean;
 	/** Determines the spacing between intermediate waypoints in path. */
 	WaypointSpacing?: number;
 	/** Table of materials or defined PathfindingModifiers and their "cost" for traversal. Useful for making the agent prefer certain materials/regions over others. */


### PR DESCRIPTION
There was one missing key in `AgentParameters`.

Relevant documentation: https://create.roblox.com/docs/reference/engine/classes/PathfindingService#CreatePath