### PR TITLE
fill in some untyped parameters

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -74,6 +74,10 @@ interface AudioAnalyzer extends Instance {
 	GetSpectrum(this: AudioAnalyzer): Array<number>;
 }
 
+interface AudioEmitter extends Instance {
+	SetDistanceAttenuation(this: AudioEmitter, curve: DistanceAttenuationCurve): void;
+}
+
 interface AvatarEditorService extends Instance {
 	GetAvatarRules(this: AvatarEditorService): AvatarRules;
 	GetBatchItemDetails(
@@ -369,6 +373,33 @@ interface GamePassService extends Instance {
 }
 
 interface GenericSettings<S = unknown> extends ServiceProvider<S> {}
+
+interface GeometryService extends Instance {
+	CalculateConstraintsToPreserve(
+		this: GeometryService,
+		source: Instance,
+		destination: Array<any>,
+		options?: CalculateConstraintsToPreserveConfig,
+	): Array<unknown>;
+	IntersectAsync(
+		this: GeometryService,
+		part: BasePart,
+		parts: Array<any>,
+		options?: GeometryServiceAsyncMethodConfig,
+	): Array<PartOperation>;
+	SubtractAsync(
+		this: GeometryService,
+		part: BasePart,
+		parts: Array<any>,
+		options?: GeometryServiceAsyncMethodConfig,
+	): Array<PartOperation>;
+	UnionAsync(
+		this: GeometryService,
+		part: BasePart,
+		parts: Array<any>,
+		options?: GeometryServiceAsyncMethodConfig,
+	): Array<PartOperation>;
+}
 
 /** @server */
 interface GlobalDataStore extends Instance {
@@ -1065,6 +1096,7 @@ interface Terrain extends BasePart {
 		materials: Array<Array<Array<CastsToEnum<Enum.Material>>>>,
 		occupancy: Array<Array<Array<number>>>,
 	): void;
+	WriteVoxelChannels(this: Terrain, region: Region3, resolution: number, channels: VoxelChannels): void;
 }
 
 interface TextBox extends GuiObject {

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -3009,3 +3009,55 @@ interface UnbanAsyncConfig {
 	 */
 	ApplyToUniverse?: boolean;
 }
+
+interface DistanceAttenuationCurve {
+	/**
+	 * Keys are expected to be unique numbers greater than or equal to 0, while values are expected to be numbers between 0 and 1 (inclusive). Tables containing up to 400 key-value pairs are supported.
+	 */
+	[key: number]: number;
+}
+
+interface CalculateConstraintsToPreserveConfig {
+	/**
+	 * The distance tolerance, in regards to `Attachment` preservation, between the attachment and the closest point on the original part's surface versus the closest point on the resulting part's surface. If the resulting distance following the solid modeling operation is greater than this value, the `Parent` of attachments and their associated constraints will be `nil` in the returned recommendation table.
+	 */
+	tolerance?: number;
+	/**
+	 * A `Enum.WeldConstraintPreserve` enum value describing how `WeldConstraints` are preserved in the resulting recommendation table.
+	 */
+	weldConstraintPreserve?: Enum.WeldConstraintPreserve;
+}
+
+interface GeometryServiceAsyncMethodConfig {
+	/**
+	 * The value of `CollisionFidelity` in the resulting parts.
+	 */
+	CollisionFidelity?: Enum.CollisionFidelity;
+	/**
+	 * The value of `FluidFidelity` in the resulting parts.
+	 */
+	RenderFidelity?: Enum.RenderFidelity;
+	/**
+	 * The value of FluidFidelity in the resulting parts.
+	 */
+	FluidFidelity?: Enum.FluidFidelity;
+	/**
+	 * Boolean controlling whether the objects should all be kept together or properly split apart. Default is `true` (split).
+	 */
+	SplitApart?: boolean;
+}
+
+interface VoxelChannels {
+	/**
+	 * The `Enum.Material` material of the voxel. Note that `Water` is not supported anymore; instead, a voxel that contains only water should be entered as `SolidMaterial = Enum.Material.Air, LiquidOccupancy = x`, where `x` is a number between 0 (exclusive) and 1 (inclusive).
+	 */
+	SolidMaterial: Enum.Material;
+	/**
+	 * The occupancy of the voxel's material as specified in the `SolidMaterial` channel. This should be a value between 0 (empty) and 1 (full).
+	 */
+	SolidOccupancy: number;
+	/**
+	 * Specifies the occupancy of the `Water` material in a voxel as a value between 0 (no water) and 1 (full of water). If the `SolidOccupancy` is 1 and the `SolidMaterial` is not `Air`, this will be 0.
+	 */
+	LiquidOccupancy: number;
+}


### PR DESCRIPTION
I went through None.d.ts looking for `: object`, trying to find parameters that didn't have children typed. 

(I hope I understand lua well enough that I filled this in correctly. My main language is javascript, so a lot of it is greek, but this seems correct.)