### PR TITLE
Remove `TestService` from PLUGIN_ONLY_CLASSES

### DIFF
--- a/src/class/ClassGenerator.ts
+++ b/src/class/ClassGenerator.ts
@@ -154,7 +154,6 @@ const PLUGIN_ONLY_CLASSES = new Set([
 	"StudioService",
 	"StudioTheme",
 	"TaskScheduler",
-	"TestService",
 	"VersionControlService",
 ]);
 


### PR DESCRIPTION
This service is not plugin-only and I used the logging methods in published games: https://create.roblox.com/docs/reference/engine/classes/TestService

EDIT: Resolves #1202