### PR TITLE
Revert "Refine Humanoid.Seated"

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -511,11 +511,7 @@ interface HttpService extends Instance {
 
 interface Humanoid extends Instance {
 	readonly AnimationPlayed: RBXScriptSignal<(animationTrack: AnimationTrack) => void>;
-	readonly Seated: RBXScriptSignal<
-		(
-			...args: [active: true, currentSeatPart: Seat | VehicleSeat] | [active: false, currentSeatPart: undefined]
-		) => void
-	>;
+	readonly Seated: RBXScriptSignal<(active: boolean, currentSeatPart: Seat | VehicleSeat | undefined) => void>;
 	readonly Touched: RBXScriptSignal<(touchingPart: BasePart, humanoidPart: BasePart) => void>;
 	GetAppliedDescription(this: Humanoid): HumanoidDescription;
 	GetPlayingAnimationTracks(this: Humanoid): Array<AnimationTrack>;


### PR DESCRIPTION
Reverts roblox-ts/types#1306

This caused issues with callbacks that only specify one parameter:
```ts
humanoid.Seated.Connect(() => {}) // OK
humanoid.Seated.Connect((seated, seat) => {}) // Works
humanoid.Seated.Connect((seated) => {}) // ERROR
```