### PR TITLE
fix: asset product info type

### DIFF
--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -190,7 +190,7 @@ interface ProductInfo {
 
 interface AssetProductInfo extends ProductInfo {
 	/** Describes whether the asset is a User Product, Developer Product, or Game Pass */
-	ProductType: "User Product";
+	ProductType?: "Collectible Item" | "User Product";
 	/** If InfoType was Asset, this is the ID of the given asset. */
 	AssetId: number;
 	/** The [type of asset](https://developer.roblox.com/articles/Asset-types) (e.g. place, model, shirt). In TypeScript, you should compare this value to a member of the `AssetTypeId` const enum. */


### PR DESCRIPTION
If an item is currently not on sale, then the product type will not necessarily exist. "Collectible Item" is also a valid type for assets.

![image](https://github.com/user-attachments/assets/a2b15b8a-3e32-4585-bd2f-ca6b7e3261ee)

![image](https://github.com/user-attachments/assets/3451ae7a-89ec-45e9-bac1-e4334ad119a0)
