### PR TITLE
Fix build js error & Update Editable(Mesh/Image) inheritance

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -540,7 +540,7 @@ interface InsertService extends Instance {
 	GetUserSets(this: InsertService, userId: number): Array<SetInfo>;
 }
 
-interface Instance {
+interface Instance extends Object {
 	/**
 	 * **Clone** creates a copy of an object and all of its descendants, ignoring all objects that are not [Archivable](https://developer.roblox.com/en-us/api-reference/property/Instance/Archivable). The copy of the root object is returned by this function and its [Parent](https://developer.roblox.com/en-us/api-reference/property/Instance/Parent) is set to nil.
 	 *

--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -341,11 +341,11 @@ interface Dragger extends Instance {
 	MouseDown(this: Dragger, mousePart: BasePart, pointOnMousePart: Vector3, parts: Array<BasePart>): void;
 }
 
-interface EditableImage extends Instance {
+interface EditableImage extends Object {
 	ReadPixels(this: EditableImage, position: Vector2, size: Vector2): Array<number>;
 }
 
-interface EditableMesh extends DataModelMesh {
+interface EditableMesh extends Object {
 	FindClosestPointOnSurface(this: EditableMesh, point: Vector3): LuaTuple<[number, Vector3, Vector3]>;
 	FindVerticesWithinSphere(this: EditableMesh, center: Vector3, radius: number): Array<number>;
 	GetAdjacentTriangles(this: EditableMesh, triangleId: number): Array<number>;


### PR DESCRIPTION
Fixes #1320
- Updates `EditableImage` and `EditableMesh` inheritance to `Object`. (Based on [this](https://devforum.roblox.com/t/studio-beta-major-updates-to-in-experience-mesh-image-apis/3225681))

This might not be the ideal solution, ever since Roblox added `Object` class, which overlaps with [roblox-ts/compiler-types](https://github.com/roblox-ts/compiler-types/blob/a13fdb1171895c7ed1a7f091d18031534e988886/types/core.d.ts#L68) version of `Object`