### PR TITLE
Remove CoreGui from PLUGIN_ONLY_CLASSES

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,7 +26,6 @@ export const CREATABLE_BLACKLIST = new Set([
 export const PLUGIN_ONLY_CLASSES = new Set([
 	"ABTestService",
 	"ChangeHistoryService",
-	"CoreGui",
 	"DataModelSession",
 	"DebuggerBreakpoint",
 	"DebuggerManager",


### PR DESCRIPTION
`CoreGui.Version` has a security level of "None".

`PLUGIN_ONLY_CLASSES` causes the generator to skip over CoreGui for "None" security.