### PR TITLE
Revert "Remove CoreGui from PLUGIN_ONLY_CLASSES"

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const CREATABLE_BLACKLIST = new Set([
 export const PLUGIN_ONLY_CLASSES = new Set([
 	"ABTestService",
 	"ChangeHistoryService",
+	"CoreGui",
 	"DataModelSession",
 	"DebuggerBreakpoint",
 	"DebuggerManager",


### PR DESCRIPTION
Reverts roblox-ts/types#1337

API dump lies. You can't actually access this at all.

<img width="643" alt="image" src="https://github.com/user-attachments/assets/6e3f722f-8729-4c24-8b20-ed1db57b7fe1" />
