### PR TITLE
Fix `lineItems` type from `PromptBulkPurchase`

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -672,6 +672,12 @@ interface MarketplaceService extends Instance {
 		user: Player,
 		subscriptionId: string,
 	): UserSubscriptionStatus;
+	PromptBulkPurchase(
+		this: MarketplaceService,
+		player: Player,
+		lineItems: Array<PromptBulkPurchaseItem>,
+		options: object,
+	): void;
 	PromptBundlePurchase(this: MarketplaceService, player: Player, bundleId: number): void;
 	PromptGamePassPurchase(this: MarketplaceService, player: Player, gamePassId: number): void;
 	PromptPremiumPurchase(this: MarketplaceService, player: Player): void;

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -3320,6 +3320,11 @@ interface ExpirationDetails {
 	ExpirationReason: Enum.SubscriptionExpirationReason;
 }
 
+interface PromptBulkPurchaseItem {
+	Id: number;
+	Type: Enum.MarketplaceProductType;
+}
+
 interface PromptBulkPurchaseFinishedResults {
 	RobuxSpent: number;
 	Items: Array<{

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -3321,7 +3321,7 @@ interface ExpirationDetails {
 }
 
 interface PromptBulkPurchaseItem {
-	Id: number;
+	Id: string;
 	Type: Enum.MarketplaceProductType;
 }
 


### PR DESCRIPTION
## Types added
- PromptBulkPurchaseItem

## Main change
changed `lineItems` type from [PromptBulkPurchase](https://create.roblox.com/docs/reference/engine/classes/MarketplaceService#PromptBulkPurchase)

![image](https://github.com/user-attachments/assets/37d3be40-833b-4df5-9fcf-7f9eef5fda5b)
