### PR TITLE
Prefer `: T | undefined` instead of `?: T` for property APIs

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -240,7 +240,7 @@ interface CollectionService extends Instance {
 }
 
 interface CompressorSoundEffect extends SoundEffect {
-	SideChain?: Sound | SoundGroup;
+	SideChain: Sound | SoundGroup | undefined;
 }
 
 interface ContentProvider extends Instance {
@@ -584,11 +584,6 @@ interface Instance extends RBXObject {
 }
 
 interface InventoryPages<T = unknown> extends Pages<T> {}
-
-interface JointInstance extends Instance {
-	Part0?: BasePart;
-	Part1?: BasePart;
-}
 
 interface JointsService extends Instance {
 	SetJoinAfterMoveInstance(this: JointsService, joinInstance: PVInstance): void;


### PR DESCRIPTION
- More consistent with auto generated APIs
- Improved compatibility with redundant override check