### PR TITLE
Fix `AssetProductInfo` type

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -672,6 +672,12 @@ interface MarketplaceService extends Instance {
 		user: Player,
 		subscriptionId: string,
 	): UserSubscriptionStatus;
+	PromptBulkPurchase(
+		this: MarketplaceService,
+		player: Player,
+		lineItems: Array<PromptBulkPurchaseItem>,
+		options: object,
+	): void;
 	PromptBundlePurchase(this: MarketplaceService, player: Player, bundleId: number): void;
 	PromptGamePassPurchase(this: MarketplaceService, player: Player, gamePassId: number): void;
 	PromptPremiumPurchase(this: MarketplaceService, player: Player): void;

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -195,11 +195,26 @@ interface ProductInfo {
 
 interface AssetProductInfo extends ProductInfo {
 	/** Describes whether the asset is a User Product, Developer Product, or Game Pass */
-	ProductType: "User Product";
+	ProductType?: "Collectible Item" | "User Product";
 	/** If InfoType was Asset, this is the ID of the given asset. */
 	AssetId: number;
 	/** The [type of asset](https://developer.roblox.com/articles/Asset-types) (e.g. place, model, shirt). In TypeScript, you should compare this value to a member of the `AssetTypeId` const enum. */
 	AssetTypeId: AssetTypeId;
+	/** Describes whether the asset is purchasable in the current experience. */
+	CanBeSoldInThisGame?: boolean;
+	CollectibleItemId?: string;
+	CollectibleProductId?: string;
+	/** A table of information describing the item collectible details. */
+	CollectiblesItemDetails?: {
+		/** Describes whether the asset is purchasable */
+		IsForSale: boolean;
+		/** Describes whether the asset is a "limited item" that is no longer (if ever) sold */
+		IsLimited: boolean;
+		/** The number of limited copies, 0 if it's not a limited item */
+		TotalQuantity: number;
+	};
+	/** The asset ID of the product/pass icon, or 0 if there isn't one. */
+	IconImageAssetId: number;
 	/** Describes whether the asset is marked as "new" in the catalog */
 	IsNew: boolean;
 	/** Describes whether the asset is a "limited item" that is no longer (if ever) sold */
@@ -210,6 +225,12 @@ interface AssetProductInfo extends ProductInfo {
 	IsPublicDomain: boolean;
 	/** The remaining number of items a limited unique item may be sold */
 	Remaining: number | undefined;
+	/** A table of information describing the sale location of the product. */
+	SaleLocation?: {
+		SaleLocationType: number;
+		/** A list of universe IDs where the product is available for purchase. */
+		UniverseIds: Array<number>;
+	};
 	/** Indicates whether the item is marked as 13+ in catalog */
 	ContentRatingTypeId: number;
 	/** The minimum Builder's Club subscription necessary to purchase the item */

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -195,15 +195,15 @@ interface ProductInfo {
 
 interface AssetProductInfo extends ProductInfo {
 	/** Describes whether the asset is a User Product, Developer Product, or Game Pass */
-	ProductType?: "Collectible Item" | "User Product";
+	ProductType: "Collectible Item" | "User Product" | undefined;
 	/** If InfoType was Asset, this is the ID of the given asset. */
 	AssetId: number;
 	/** The [type of asset](https://developer.roblox.com/articles/Asset-types) (e.g. place, model, shirt). In TypeScript, you should compare this value to a member of the `AssetTypeId` const enum. */
 	AssetTypeId: AssetTypeId;
 	/** Describes whether the asset is purchasable in the current experience. */
-	CanBeSoldInThisGame?: boolean;
-	CollectibleItemId?: string;
-	CollectibleProductId?: string;
+	CanBeSoldInThisGame: boolean | undefined;
+	CollectibleItemId: string | undefined;
+	CollectibleProductId: string | undefined;
 	/** A table of information describing the item collectible details. */
 	CollectiblesItemDetails?: {
 		/** Describes whether the asset is purchasable */

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -3320,6 +3320,11 @@ interface ExpirationDetails {
 	ExpirationReason: Enum.SubscriptionExpirationReason;
 }
 
+interface PromptBulkPurchaseItem {
+	Id: number;
+	Type: Enum.MarketplaceProductType;
+}
+
 interface PromptBulkPurchaseFinishedResults {
 	RobuxSpent: number;
 	Items: Array<{

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -3321,7 +3321,7 @@ interface ExpirationDetails {
 }
 
 interface PromptBulkPurchaseItem {
-	Id: number;
+	Id: string;
 	Type: Enum.MarketplaceProductType;
 }
 


### PR DESCRIPTION
## Added
- CanBeSoldInThisGame
- CollectibleItemId
- CollectibleProductId
- CollectiblesItemDetails
- IconImageAssetId
- SaleLocation

![image](https://github.com/user-attachments/assets/9ed37e22-a4a5-4af2-9111-da99d13a5217)
![image](https://github.com/user-attachments/assets/58fd2afb-49e8-4b2b-8c46-b346c7864b7e)

## Modified
- ProductType: for some AssetTypesIds ProductType is `undefined` or `Collectible Item`

![image](https://github.com/user-attachments/assets/9280b7aa-2bbe-4f34-b651-8c54ca52e0eb)
![image](https://github.com/user-attachments/assets/8d929d46-4ca3-4d92-a748-02a4b411759b)