### PR TITLE
Prevent empty enums from being emitted

### DIFF
--- a/src/generator/enums/createEnumNamespace.ts
+++ b/src/generator/enums/createEnumNamespace.ts
@@ -120,6 +120,10 @@ function createEnumItemVariable(apiEnumItem: ApiEnumItem) {
 }
 
 export function createEnumNamespace(ctx: Context, apiEnum: ApiEnum) {
+	if (apiEnum.Items.length === 0) {
+		return [];
+	}
+
 	const namespaceStatements = new Array<ts.Statement>();
 
 	for (const apiEnumItem of apiEnum.Items) {


### PR DESCRIPTION
[A new enum was added with 0 public enum items](https://robloxapi.github.io/ref/enum/AudioCaptureMode.html). This is likely just in-progress work which is partially shipped by Roblox.

The enum generator did not handle this correctly and it resulted in a definition of:
```ts
    /**
     * [Creator Hub](https://create.roblox.com/docs/reference/engine/enums/AudioCaptureMode)
     */
    export namespace AudioCaptureMode {
        export function GetEnumItems(this: globalThis.Enum): Array<globalThis.Enum.AudioCaptureMode>;
        export function FromName(this: globalThis.Enum, name: string): globalThis.Enum.AudioCaptureMode | undefined;
        export function FromValue(this: globalThis.Enum, value: number): globalThis.Enum.AudioCaptureMode | undefined;
    }
    export type AudioCaptureMode = ;
```

This can cause compiler errors in user code.

To fix this, I made it skip any enums which have `apiEnum.Items.length === 0`