### PR TITLE
Make SharedTable iterable

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -196,4 +196,5 @@ export const EXPECTED_EXTRA_MEMBERS = new Map([
 	["ValueBase", ["Value", "Changed"]],
 	["DataStore", ["GetAsync", "IncrementAsync", "SetAsync", "UpdateAsync", "RemoveAsync"]],
 	["OrderedDataStore", ["GetAsync", "IncrementAsync", "SetAsync", "UpdateAsync", "RemoveAsync"]],
+	["SharedTable", ["[Symbol.iterator]"]],
 ]);

--- a/src/generator/enums/createEnumsSourceFile.ts
+++ b/src/generator/enums/createEnumsSourceFile.ts
@@ -175,6 +175,27 @@ export function createEnumsSourceFile(ctx: Context) {
 		),
 	);
 
+	// declare type IterableFunction<T> = (this: void) => T;
+	statements.push(
+		ts.factory.createTypeAliasDeclaration(
+			[ts.factory.createToken(ts.SyntaxKind.DeclareKeyword)],
+			ts.factory.createIdentifier("IterableFunction"),
+			[
+				ts.factory.createTypeParameterDeclaration(
+					undefined,
+					ts.factory.createIdentifier("T"),
+					undefined,
+					undefined,
+				),
+			],
+			ts.factory.createFunctionTypeNode(
+				undefined,
+				[ts.factory.createParameterDeclaration(undefined, undefined, "this", undefined, ts.factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword))],
+				ts.factory.createTypeReferenceNode("T"),
+			),
+		),
+	);
+
 	// declare type CastsToEnum<T extends EnumItem> = T | T["Name" | "Value"];
 	statements.push(
 		ts.factory.createTypeAliasDeclaration(

--- a/src/generator/enums/createEnumsSourceFile.ts
+++ b/src/generator/enums/createEnumsSourceFile.ts
@@ -190,7 +190,15 @@ export function createEnumsSourceFile(ctx: Context) {
 			],
 			ts.factory.createFunctionTypeNode(
 				undefined,
-				[ts.factory.createParameterDeclaration(undefined, undefined, "this", undefined, ts.factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword))],
+				[
+					ts.factory.createParameterDeclaration(
+						undefined,
+						undefined,
+						"this",
+						undefined,
+						ts.factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword),
+					),
+				],
 				ts.factory.createTypeReferenceNode("T"),
 			),
 		),

--- a/src/generator/instances/classes/createInstanceInterface.ts
+++ b/src/generator/instances/classes/createInstanceInterface.ts
@@ -78,7 +78,7 @@ export function createInstanceInterface(ctx: Context, apiClass: ApiClass, securi
 		apiClass.Superclass === "<<<ROOT>>>" ? undefined : [createExtendsClause(getSafeClassName(apiClass.Superclass))];
 
 	const overrideMembers = new Map<string, Array<ts.TypeElement>>();
-	
+
 	if (apiClass.Name === "SharedTable") {
 		const keyType = ts.factory.createTypeParameterDeclaration(
 			undefined,
@@ -109,13 +109,9 @@ export function createInstanceInterface(ctx: Context, apiClass: ApiClass, securi
 			]),
 		);
 
-		getOrSetDefault(
-			overrideMembers,
-			"[Symbol.iterator]",
-			() => new Array<ts.TypeElement>(),
-		).push(iter);
+		getOrSetDefault(overrideMembers, "[Symbol.iterator]", () => new Array<ts.TypeElement>()).push(iter);
 	}
-	
+
 	const overrideInterface = overrideInterfaceMap.get(getSafeClassName(apiClass.Name));
 	if (overrideInterface) {
 		for (const member of overrideInterface.members) {


### PR DESCRIPTION
Fixes #1378

This introduces a [Symbol.iterator] to the SharedTable interface allowing it to be used directly in a for...of loop


```
const st: SharedTable<{ myKey: number }> = SharedTable.new({ myKey: 123 });

for (const [key, value] of st) {
	// key is "myKey"
	// value is 123
}
```