### PR TITLE
Fix `MemoryStoreService:UpdateAsync` types

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -730,9 +730,12 @@ interface MemoryStoreSortedMap extends Instance {
 	UpdateAsync<T>(
 		this: MemoryStoreSortedMap,
 		key: string,
-		transformFunction: (value: unknown) => T,
+		transformFunction: (
+			value: unknown,
+			sortKey?: string | number,
+		) => LuaTuple<[value: T, sortKey?: string | number]> | undefined,
 		expiration: number,
-	): T;
+	): LuaTuple<[value?: T, sortKey?: string | number]>;
 	SetAsync(
 		this: MemoryStoreSortedMap,
 		key: string,


### PR DESCRIPTION
I'm a little uncertain about the `LuaTuple` types here. I don't know if there's precedent in the types for how to handle "nullable" multi-returns.

I think that this type is fine for the transform function return because it tells the user that they need to return nothing at all, or the value, or the value and the sortKey, not just the sortKey.

```ts
LuaTuple<[value: T, sortKey?: string | number]> | undefined
```


Fixes #1394
