### PR TITLE
Fix build: remove overrides for deleted RemoteCreate* signals

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -1320,17 +1320,11 @@ interface WorldRoot extends Model {
 	GetPartsInPart(this: WorldRoot, part: BasePart, overlapParams?: OverlapParams): Array<BasePart>;
 }
 
-interface Platform extends Part {
-	readonly RemoteCreateMotor6D: RBXScriptSignal<(humanoid: Humanoid) => void>;
-}
-
 interface SkateboardPlatform extends Part {
 	readonly Equipped: RBXScriptSignal<(humanoid: Humanoid, skateboardController: SkateboardController) => void>;
-	readonly RemoteCreateMotor6D: RBXScriptSignal<(humanoid: Humanoid) => void>;
 	readonly Unequipped: RBXScriptSignal<(humanoid: Humanoid) => void>;
 }
 
 interface Seat extends Part {
 	Sit(this: Seat, humanoid: Humanoid | undefined): void;
-	readonly RemoteCreateSeatWeld: RBXScriptSignal<(humanoid: Humanoid) => void>;
 }


### PR DESCRIPTION
## Problem

The daily scheduled **Build** workflow has failed every run since **2026-06-17**, aborting with:

```
Error: Unexpected extra member: Platform.RemoteCreateMotor6D
    at createInstanceInterface (.../createInstanceInterface.js:137)
```

## Root cause

The build regenerates types from the live Roblox API dump (`MaximumADHD/Roblox-Client-Tracker` → `Mini-API-Dump.json`). Roblox **removed several `RemoteCreate*` signals** from the API:

- `Platform.RemoteCreateMotor6D` — the `Platform` class now has **zero** members in the dump
- `SkateboardPlatform.RemoteCreateMotor6D`
- `Seat.RemoteCreateSeatWeld`

`include/customDefinitions.d.ts` still hand-overrode these members. The generator (`createInstanceInterface.ts`) only permits an override member if it also exists in the live dump or is whitelisted in `EXPECTED_EXTRA_MEMBERS`; otherwise it throws `Unexpected extra member`. The build fails on `Platform` first, with `SkateboardPlatform` and `Seat` next in line.

## Fix

Remove the three stale overrides. The `Platform` override interface held only the removed member, so it is dropped entirely. All other overrides on these classes (`SkateboardPlatform.Equipped`/`Unequipped`, `Seat.Sit`) remain because they still correspond to real dump members.

I audited every override interface in `customDefinitions.d.ts` against the current dump using the TypeScript compiler API — these three were the only stale members.

## Verification

- `npm run build` → exit 0 (previously exit 1)
- `npm run check` (typecheck) → exit 0

Generated files under `include/generated/` are intentionally **not** included — they regenerate automatically after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjymQjMbjeupW5Fr3SWcnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjymQjMbjeupW5Fr3SWcnZ)_