### PR TITLE
Handle &lt;pre&gt;&lt;code&gt; doc blocks without a class attribute

### DIFF
--- a/src/util/transformHtml.ts
+++ b/src/util/transformHtml.ts
@@ -73,7 +73,7 @@ const TAG_TRANSFORMERS: { [K in string]?: (node: Element) => string } = {
 		assertTag(codeNode, "code", "Unexpected pre child");
 		// <pre><code class=\"language-lua\">
 		const className = codeNode.attribs.class;
-		const language = className.startsWith("language-") ? className.slice("language-".length) : "";
+		const language = className?.startsWith("language-") ? className.slice("language-".length) : "";
 		return `\n\`\`\`${language}\n${transformNodeList(codeNode.children)}\n\`\`\``;
 	},
 	a: node => `[${transformNodeList(node.children)}](${node.attribs.href})`,


### PR DESCRIPTION
## Problem

During the build, doc transformation logs repeated non-fatal errors:

```
Failed to transform docs: TypeError: Cannot read properties of undefined (reading 'startsWith')
    at pre (.../transformHtml.js:73)
```

The `pre` tag transformer in `src/util/transformHtml.ts` assumed every `<code>` child of a `<pre>` carried a `class` attribute:

```ts
const className = codeNode.attribs.class;
const language = className.startsWith("language-") ? ... : "";
```

Some Roblox documentation contains `<pre><code>` blocks with **no** `class`, so `className` is `undefined` and `.startsWith(...)` throws. The error is caught upstream, but the affected member loses its doc comment.

This does **not** fail the build on its own — it's a latent bug surfaced by new upstream doc content. (The hard build failure is addressed separately in #1409.)

## Fix

Guard the access with optional chaining so a missing `class` falls back to an unlabeled code block:

```ts
const language = className?.startsWith("language-") ? className.slice("language-".length) : "";
```

## Verification

- `npm run build` no longer logs any `Failed to transform docs: ... startsWith` errors (count went from several to 0).
- `npx eslint "src/**/*.ts" --max-warnings 0` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjymQjMbjeupW5Fr3SWcnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjymQjMbjeupW5Fr3SWcnZ)_