### PR TITLE
fix: correct OutfitPages extends type (remove extra ReadonlyArray wrapper)

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -152,13 +152,11 @@ interface CaptureService extends Instance {
 interface CatalogPages extends Pages<SearchCatalogResult> {}
 
 interface OutfitPages
-	extends Pages<
-		ReadonlyArray<{
-			Id: number;
-			Name: string;
-			IsEditable: boolean;
-		}>
-	> {}
+	extends Pages<{
+		Id: number;
+		Name: string;
+		IsEditable: boolean;
+	}> {}
 
 interface BadgeService extends Instance {
 	/** @server */


### PR DESCRIPTION
## Problem

`OutfitPages` incorrectly extends `Pages<ReadonlyArray<{Id: number; Name: string; IsEditable: boolean}>>`.

The `ReadonlyArray` wrapper doesn't match the Roblox API — `OutfitPages:GetCurrentPage()` returns individual items, not an array.

## Fix

Remove the extra `ReadonlyArray` wrapper to match the actual API:

```diff
- Pages<ReadonlyArray<{Id: number; Name: string; IsEditable: boolean}>>
+ Pages<{Id: number; Name: string; IsEditable: boolean}>
```

This matches the pattern used by similar page types like `FriendPages`.

Fixes #1368