### PR TITLE
Add `e`, `nan`, `phi`, `sqrt2`, `tau` constant to `math` namespace

### DIFF
--- a/include/lua.d.ts
+++ b/include/lua.d.ts
@@ -460,6 +460,21 @@ declare namespace math {
 	/** The value HUGE_VAL, a value larger than or equal to any other numerical value. */
 	const huge: number;
 
+	/** The value of Euler's number, e. */
+	const e: number;
+
+	/** A NaN value, as defined by the IEEE 754 standard. Comparing directly to `math.nan` will always return false; use `math.isnan()` instead. */
+	const nan: number;
+
+	/** The value of the golden ratio. */
+	const phi: number;
+
+	/** The value of the square root of 2. */
+	const sqrt2: number;
+
+	/** The value of tau, which is defined as `2 * math.pi` */
+	const tau: number;
+
 	/** Returns the absolute value of x. */
 	function abs(n: number): number;
 


### PR DESCRIPTION
Add several missing constants of math
https://create.roblox.com/docs/en-us/reference/engine/libraries/math