### PR TITLE
Fix return type of `ScriptEditorService.GetScriptDocuments()`

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -1327,3 +1327,7 @@ interface SkateboardPlatform extends Part {
 interface Seat extends Part {
 	Sit(this: Seat, humanoid: Humanoid | undefined): void;
 }
+
+interface ScriptEditorService extends Instance {
+	GetScriptDocuments(this: ScriptEditorService): Array<ScriptDocument>;
+}


### PR DESCRIPTION
Change return type of `ScriptEditorService.GetScriptDocuments()` from `Array<Instance>` to `Array<ScriptDocument>` to match with Roblox studio
<img width="804" height="215" alt="image" src="https://github.com/user-attachments/assets/c9ec3da6-2184-49e2-92e1-5cc22385e46f" />